### PR TITLE
Get rid of special sort for "web".

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,6 +1,6 @@
 class ProjectsController < ApplicationController
   def index
-    @projects = Project.find_all_by_name('web') | Project.all(:order => "name ASC")
+    @projects = Project.order("name ASC")
   end
 
   def ci_projects

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -4,6 +4,18 @@ require 'rexml/document'
 describe ProjectsController do
   render_views
 
+  describe "#index" do
+    let(:a) { FactoryGirl.create(:project, name: 'aster') }
+    let(:b) { FactoryGirl.create(:project, name: 'buckeye') }
+    let(:c) { FactoryGirl.create(:project, name: 'creosote') }
+
+    it "shows projects in order" do
+      b; a; c
+      get :index
+      assigns(:projects).map(&:name).should == %w{aster buckeye creosote}
+    end
+  end
+
   describe "#ci_projects" do
     let(:repository) { FactoryGirl.create(:repository) }
     let!(:ci_project) { FactoryGirl.create(:project, :name => repository.repository_name) }


### PR DESCRIPTION
The pages /projects currently sorts a project named "web" at the top. Not only is this a Square-ism,
but I doubt it even makes sense for Square these days. @robolson @nolman
