### PR TITLE
Don't complain if we can't find a pull request repository.

### DIFF
--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -28,6 +28,7 @@ class PullRequestsController < ApplicationController
 
   def handle_pull_request
     repository = Repository.find_by_url(payload['repository']['ssh_url'])
+    return unless repository
     project = repository.projects.where(name: repository.repository_name + "-pull_requests").first_or_create
     if active_pull_request? && (build_requested_for_pull_request? || repository.build_pull_requests)
       sha = payload["pull_request"]["head"]["sha"]

--- a/spec/controllers/pull_requests_controller_spec.rb
+++ b/spec/controllers/pull_requests_controller_spec.rb
@@ -194,6 +194,14 @@ describe PullRequestsController do
             response.should be_success
           }.to_not change(Build, :count)
         end
+
+        it "it should not error if the repository url in the request is not found" do
+          expect {
+            post :build, 'payload' => pull_request_payload(
+                "repository" => { "ssh_url" => "git@none.git" })
+            response.should be_success
+          }.to_not change(Build, :count)
+        end
       end
     end
   end


### PR DESCRIPTION
For example, the repository is set up in github and not kochiku.

This parallels what we are already doing elsewhere in the pull_requests_controller.

@robolson 
