### PR TITLE
More robust URL parsing.

### DIFF
--- a/app/models/remote_server/github.rb
+++ b/app/models/remote_server/github.rb
@@ -8,8 +8,29 @@ module RemoteServer
   class Github
     attr_reader :repo
 
+    URL_PARSERS = {
+      "git@" => %r{@(.*):(.*)/(.*)\.git},
+      "git:" => %r{://(.*)/(.*)/(.*)\.git},
+      "http" => %r{https?://(.*)/(.*)/([^.]*)\.?},
+    }
+
     def self.convert_to_ssh_url(params)
       "git@#{params[:host]}:#{params[:username]}/#{params[:repository]}.git"
+    end
+
+    def self.project_params(url)
+      parser = URL_PARSERS[url.slice(0,4)]
+      match = url.match(parser)
+
+      if match
+        {
+          host:       match[1],
+          username:   match[2],
+          repository: match[3]
+        }
+      else
+        raise UnknownUrl, "Do not recognize #{url} as a github url."
+      end
     end
 
     def initialize(repo)

--- a/app/models/remote_server/stash.rb
+++ b/app/models/remote_server/stash.rb
@@ -4,6 +4,20 @@ module RemoteServer
   class Stash
     attr_reader :repo, :stash_request
 
+    def self.project_params(url)
+      match = url.match(%r{https://([^@]+)/scm/(.+)/(.+)\.git})
+
+      if match
+        {
+          host:       match[1],
+          username:   match[2],
+          repository: match[3],
+        }
+      else
+        raise UnknownUrl, "Do not recognize #{url} as a stash HTTPS url."
+      end
+    end
+
     def self.convert_to_ssh_url(params)
       "git@#{params[:host]}:#{params[:port]}/#{params[:username].downcase}/#{params[:repository]}.git"
     end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,12 +1,6 @@
 class Repository < ActiveRecord::Base
   UnknownServer = Class.new(RuntimeError)
 
-  URL_PARSERS = {
-    "git@" => %r{@(.*):(.*)/(.*)\.git},
-    "git:" => %r{://(.*)/(.*)/(.*)\.git},
-    "http" => %r{https?://(.*)/(.*)/([^.]*)\.?},
-    'ssh:' => %r{ssh://git@(.*):(\d+)/(.*)/([^.]+)\.git}
-  }
   has_many :projects, :dependent => :destroy
   validates_presence_of :url
   validates_uniqueness_of :repository_name
@@ -92,26 +86,6 @@ class Repository < ActiveRecord::Base
   def self.project_params(url)
     return {} unless url.present?
 
-    # TODO: Move these parsers to RemoteServer classes. Or at least be more lenient about
-    # the format.
-    parser = URL_PARSERS[url.slice(0,4)]
-    match = url.match(parser)
-
-    raise "don't yet understand git URL #{url}" unless match
-
-    if match.length > 4
-      {
-        host:       match[1],
-        port:       match[2].to_i,
-        username:   match[3],
-        repository: match[4]
-      }
-    else
-      {
-        host:       match[1],
-        username:   match[2],
-        repository: match[3]
-      }
-    end
+    remote_server(url).project_params(url)
   end
 end

--- a/app/models/unknown_url.rb
+++ b/app/models/unknown_url.rb
@@ -1,0 +1,2 @@
+# Thrown by code that auto-detects properties from a given URL.
+UnknownUrl = Class.new(RuntimeError)

--- a/config/application.test.yml
+++ b/config/application.test.yml
@@ -1,0 +1,39 @@
+# Email address to use in the 'from' field for emails sent by Kochiku.
+sender_email_address: 'kochiku@example.com'
+
+# Email address where kochiku should send problems with the build system (for example, errors),
+# as distinct from failures in a particular test (which go to the people who committed code).
+kochiku_notifications_email_address: 'kochiku-notifications@example.com'
+
+# Domain name to use in constructing generic addresses. For example noreply@example.com in git commits.
+domain_name: 'example.com'
+
+# Set to true if Kochiku is served over https
+use_https: false
+
+# Host name where Kochiku is serving web pages.
+kochiku_host: 'kochiku.example.com'
+
+# If you commit with hitch/git-pair, etc, set this in order to send email to each person in the pair.
+# For example, github+joe+bob@example.com will turn into emails to joe@example.com and bob@example.com
+# if git_pair_email_prefix is set to 'github'.
+git_pair_email_prefix: 'github'
+
+# Mail server which will accept mail on port 25 (standard SMTP port). If you need to use another port,
+# or other settings, you currently need to edit the kochiku source (config.action_mailer settings in
+# config/environments/production.rb).
+smtp_server: 'localhost'
+
+# List your git servers (at least for now, they need to be either github, github enterprise, or
+# Atlassian Stash for things like constructing URLs to pages on those servers. Would be nice to
+# just turn off the fancy features for a vanilla git server instead, but that isn't yet possible).
+# possible values for type are: github or stash
+git_servers:
+  github.com:
+    type: github
+  git.example.com:
+    type: github
+  git.squareup.com:
+    type: github
+  stash.example.com:
+    type: stash

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,7 +4,11 @@ require File.expand_path('../application', __FILE__)
 # Load application settings for Kochiku
 require File.expand_path('../../lib/settings_accessor', __FILE__)
 
-CONF_FILE = File.expand_path('../application.yml', __FILE__)
+CONF_FILE = if Rails.env.test?
+  File.expand_path('../application.test.yml', __FILE__)
+else
+  File.expand_path('../application.yml', __FILE__)
+end
 
 if !File.exist?(CONF_FILE)
   raise "#{CONF_FILE} is required to start Kochiku"

--- a/spec/controllers/pull_requests_controller_spec.rb
+++ b/spec/controllers/pull_requests_controller_spec.rb
@@ -4,6 +4,8 @@ describe PullRequestsController do
   before do
     settings = SettingsAccessor.new(<<-YAML)
     git_servers:
+      github.com:
+        type: github
       git.example.com:
         type: github
     YAML

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -47,13 +47,13 @@ describe BuildPart do
   end
 
   describe "#job_args" do
-    let(:repository) { FactoryGirl.create(:repository, :url => "git@git.example.com:org/test-repo.git") }
+    let(:repository) { FactoryGirl.create(:repository, :url => "git@github.com:org/test-repo.git") }
 
     context "with a git mirror specified" do
       before do
         settings = SettingsAccessor.new(<<-YAML)
         git_servers:
-          git.example.com:
+          github.com:
             type: github
             mirror: "git://git-mirror.example.com/"
         YAML
@@ -71,7 +71,7 @@ describe BuildPart do
       before do
         settings = SettingsAccessor.new(<<-YAML)
         git_servers:
-          git.example.com:
+          github.com:
             type: github
         YAML
         stub_const "Settings", settings

--- a/spec/models/remote_server/github_spec.rb
+++ b/spec/models/remote_server/github_spec.rb
@@ -48,4 +48,12 @@ describe RemoteServer::Github do
       end
     end
   end
+
+  describe '.project_params' do
+    it 'raises UnknownUrl for invalid urls' do
+      expect { described_class.project_params \
+        "https://github.com/blah"
+      }.to raise_error(UnknownUrl)
+    end
+  end
 end

--- a/spec/models/remote_server/stash_spec.rb
+++ b/spec/models/remote_server/stash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe RemoteServer do
+describe 'stash integration test' do
   before do
     settings = SettingsAccessor.new(<<-YAML)
     git_servers:
@@ -14,31 +14,61 @@ describe RemoteServer do
     allow(File).to receive(:read).with("/password").and_return("stashpassword")
   end
 
-  let(:repository) { FactoryGirl.create(:repository, url: 'git@stash.example.com:/foo/bar.git')}
+  let(:repository) { FactoryGirl.create(:repository, url: 'https://stash.example.com/scm/foo/bar.git')}
   let(:stash) { RemoteServer::Stash.new(repository) }
   let(:stash_request) { stash.stash_request }
 
-  describe RemoteServer::StashRequest do
-    describe ".setup_auth!" do
-      it "should send username and password on" do
-        request = double()
-        expect(request).to receive(:basic_auth).with("stashuser", "stashpassword")
-        stash_request.setup_auth!(request)
-      end
+  describe ".setup_auth!" do
+    it "should send username and password on" do
+      request = double()
+      expect(request).to receive(:basic_auth).with("stashuser", "stashpassword")
+      stash_request.setup_auth!(request)
     end
   end
 
-  describe RemoteServer::Stash do
-    describe "#update_commit_status!" do
-      let(:build) { FactoryGirl.create(:build) }
+  describe "#update_commit_status!" do
+    let(:build) { double('build',
+      ref:        'abc123',
+      project:    double('project'),
+      succeeded?: true,
+      id:         123
+    ) }
 
-      it "should post to stash" do
-        stub_request(:post, "https://stashuser:stashpassword@stash.example.com/rest/build-status/1.0/commits/#{build.ref}")
+    it "should post to stash" do
+      stub_request(:post, "https://stashuser:stashpassword@stash.example.com/rest/build-status/1.0/commits/#{build.ref}")
 
-        stash.update_commit_status!(build)
+      stash.update_commit_status!(build)
 
-        WebMock.should have_requested(:post, "https://stashuser:stashpassword@stash.example.com/rest/build-status/1.0/commits/#{build.ref}")
-      end
+      WebMock.should have_requested(:post, "https://stashuser:stashpassword@stash.example.com/rest/build-status/1.0/commits/#{build.ref}")
+    end
+  end
+end
+
+describe RemoteServer::Stash do
+  describe '.project_params' do
+    it 'parses HTTPS url' do
+      result = described_class.project_params \
+        "https://stash.example.com/scm/myproject/myrepo.git"
+
+      expect(result).to eq(
+        host:       'stash.example.com',
+        username:   'myproject',
+        repository: 'myrepo'
+      )
+    end
+
+    it 'does not support HTTP auth credentials in URL' do
+      # Use a netrc file instead.
+      expect { described_class.project_params \
+        "https://don@stash.example.com/scm/myproject/myrepo.git"
+      }.to raise_error(UnknownUrl)
+    end
+
+    it 'does not support ssh URLs' do
+      # It could support ssh URLs in the future if you wanted to implement it.
+      expect { described_class.project_params \
+        "ssh://git@stash.example.com:7999/myproject/myrepo.git"
+      }.to raise_error(UnknownUrl)
     end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -8,6 +8,8 @@ describe Repository do
         type: stash
       git.example.com:
         type: github
+      github.com:
+        type: github
     YAML
     stub_const "Settings", settings
   end
@@ -127,23 +129,26 @@ describe Repository do
   end
 
   context "with stash repository" do
+    before do
+      allow(Settings).to receive(:stash_host).and_return('stash.example.com')
+    end
+
+    let(:repo) {
+      Repository.new(url: "https://stash.example.com/scm/myproject/myrepo.git").tap(&:valid?)
+    }
+
     context "#repository_name" do
       it "returns the repositories name" do
-        repo = Repository.new(url: "ssh://git@stash.example.com:7999/pe/host-tools.git")
-        repo.valid?
-        repo.repository_name.should == "host-tools"
+        repo.repository_name.should == "myrepo"
       end
     end
 
     context '.project_params' do
       it 'parses out pertinent information' do
-        repo = Repository.new(url: "ssh://git@stash.example.com:7999/pe/host-tools.git")
-        repo.valid?
         expect(repo.project_params).to eq(
           host:       'stash.example.com',
-          port:       7999,
-          username:   'pe',
-          repository: 'host-tools'
+          username:   'myproject',
+          repository: 'myrepo'
         )
       end
     end


### PR DESCRIPTION
- Support HTTPS stash URLs. (Motivation for PR.)
- Push `project_params` down into RemoteServer classes.
- Raise a proper error for invalid Github URLs.

@jkingdon 
