### PR TITLE
Fix two little nits in partition error code

### DIFF
--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -46,7 +46,7 @@
     %span.info
       = button_to "Rebuild failed parts", rebuild_failed_parts_project_build_path(@project, @build), :method => :post, :form_class => "rebuild-parts"
 
-- if !@build.error_details.empty?
+- if @build.error_details.present?
   .build-error
     %h2 Build error
     %pre= [@build.error_details[:message], @build.error_details[:backtrace]].join("\n")

--- a/spec/jobs/build_partitioning_job_spec.rb
+++ b/spec/jobs/build_partitioning_job_spec.rb
@@ -39,7 +39,7 @@ describe BuildPartitioningJob do
       end
     end
 
-    context "when a none-retryable error occurs" do
+    context "when a non-retryable error occurs" do
       error_message = "A name error occurred"
       before { GitRepo.stub(:inside_copy).and_raise(NameError.new(error_message)) }
 


### PR DESCRIPTION
- "none" -> "non" spelling
- use .present? instead of !.empty?
