### PR TITLE
Don't specify socket for development mysql.

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,6 @@ development: &defaults
   pool: 5
   username: root
   password:
-  socket: /tmp/mysql.sock
 
 
 # Warning: The database defined as "test" will be erased and


### PR DESCRIPTION
Different systems put the socket file in different places and so it
seems like a bad idea to specify it in our checked in database.yml.

See for example https://stackoverflow.com/questions/5499035/ruby-on-rails-3-cant-connect-to-local-mysql-server-through-socket-tmp-mysql-s - running `mysqladmin variables | grep socket` on my Ubuntu 12.4 system (unmodified as far as I recall) returns `/var/run/mysqld/mysqld.sock`.

@robolson 
