### PR TITLE
Passing a block to .with is deprecated in rspec 2.99, removed in 3.0.

### DIFF
--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -21,16 +21,15 @@ describe BuildPart do
 
     it "enqueues onto the queue specified in the build part" do
       build_part.update_attribute(:queue, 'queueX')
-      expect(BuildAttemptJob).to receive(:enqueue_on).once.with { |queue, arg_hash|
+      expect(BuildAttemptJob).to receive(:enqueue_on).once do |queue, arg_hash|
         expect(queue).to eq("queueX")
-        true
-      }
+      end
       build_part.create_and_enqueue_new_build_attempt!
     end
 
     it "should enqueue the build attempt for building" do
       build_part.update_attributes!(:options => {"ruby" => "ree"})
-      expect(BuildAttemptJob).to receive(:enqueue_on).once.with { |queue, arg_hash|
+      expect(BuildAttemptJob).to receive(:enqueue_on).once do |queue, arg_hash|
         expect(queue).to eq("ci")
         expect(arg_hash["build_attempt_id"]).not_to be_blank
         expect(arg_hash["build_ref"]).not_to be_blank
@@ -40,8 +39,7 @@ describe BuildPart do
         expect(arg_hash["test_command"]).not_to be_blank
         expect(arg_hash["repo_url"]).not_to be_blank
         expect(arg_hash["options"]).to eq({"ruby" => "ree"})
-        true
-      }
+      end
       build_part.create_and_enqueue_new_build_attempt!
     end
   end
@@ -237,7 +235,7 @@ describe BuildPart do
 
     context "for a non merge_on_success branch build" do
       before { expect(build.merge_on_success).to be_false }
-      
+
       it "will not reattempt" do
         expect(build_part.should_reattempt?).to be_false
       end

--- a/spec/models/remote_server/github_spec.rb
+++ b/spec/models/remote_server/github_spec.rb
@@ -6,15 +6,15 @@ describe RemoteServer::Github do
     let(:server) { described_class.new(repo) }
 
     it 'creates branch if it does not exist' do
-      expect(GithubRequest).to receive(:post).with { |uri, args|
-        args[:ref] == 'refs/heads/deployable-myapp' &&
-          args[:sha] == 'abc123'
-      }
-      expect(GithubRequest).to receive(:patch).with { |uri, args|
+      expect(GithubRequest).to receive(:post) do |uri, args|
+        expect(args[:ref]).to eq('refs/heads/deployable-myapp')
+        expect(args[:sha]).to eq('abc123')
+      end
+      expect(GithubRequest).to receive(:patch) do |uri, args|
         expect(uri.to_s).to match(/deployable-myapp\Z/)
         expect(args[:force]).to eq('true')
         expect(args[:sha]).to eq('abc123')
-      }
+      end
       server.promote_branch!('deployable-myapp', 'abc123')
     end
 
@@ -22,11 +22,11 @@ describe RemoteServer::Github do
       expect(GithubRequest)
         .to receive(:post)
         .and_raise(GithubRequest::ResponseError)
-      expect(GithubRequest).to receive(:patch).with { |uri, args|
+      expect(GithubRequest).to receive(:patch) do |uri, args|
         expect(uri.to_s).to match(/deployable-myapp\Z/)
         expect(args[:force]).to eq('true')
         expect(args[:sha]).to eq('abc123')
-      }
+      end
       server.promote_branch!('deployable-myapp', 'abc123')
     end
   end


### PR DESCRIPTION
Is this what you had in mind, @yujinakayama (in your comments on #48)?

@robolson @nolman 
