### PR TITLE
Specifying the port in Stash SSH URLs is optional

### DIFF
--- a/app/models/remote_server/stash.rb
+++ b/app/models/remote_server/stash.rb
@@ -7,8 +7,9 @@ module RemoteServer
     attr_reader :repo, :stash_request
 
     URL_PARSERS = [
-      %r{git@(?<host>.*?)(?<port>:\d+)?/(?<username>.*)/(?<project_name>.*)\.git},  # ssh
-      %r{https://(?<host>[^@]+)/scm/(?<username>.+)/(?<project_name>.+)\.git}, # https
+      %r{\Agit@(?<host>.*):(?<username>.*)/(?<project_name>.*)\.git\z},
+      %r{\Assh://git@(?<host>.*?)(?<port>:\d+)?/(?<username>.*)/(?<project_name>.*)\.git\z},
+      %r{\Ahttps://(?<host>[^@]+)/scm/(?<username>.+)/(?<project_name>.+)\.git\z},
     ]
 
     def self.project_params(url)

--- a/spec/models/remote_server/stash_spec.rb
+++ b/spec/models/remote_server/stash_spec.rb
@@ -66,6 +66,17 @@ describe RemoteServer::Stash do
 
     it 'parses ssh URLs' do
       result = described_class.project_params \
+        "git@stash.example.com:myproject/myrepo.git"
+
+      expect(result).to eq(
+        host:       'stash.example.com',
+        username:   'myproject',
+        repository: 'myrepo'
+      )
+    end
+
+    it 'parses ssh URLs prefixed with ssh://' do
+      result = described_class.project_params \
         "ssh://git@stash.example.com/myproject/myrepo.git"
 
       expect(result).to eq(


### PR DESCRIPTION
to @xaviershay 

All of our Stash SSH URLs used to have ports in them but now they don't. This changes the parser to the make the port optional.
