### PR TITLE
Add build artifact view to be able to view log contents w/o downloading the file

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -573,3 +573,11 @@ ol#build-paths
 
 p
   line-height: 1.4em
+
+#log_output
+  background-color: black
+  color: white
+  font-size: 1.02em
+  line-height: 1.2em
+  padding: 5px
+  font-family: "Lucida Console", Monaco, monospace

--- a/app/controllers/build_artifacts_controller.rb
+++ b/app/controllers/build_artifacts_controller.rb
@@ -1,6 +1,6 @@
 class BuildArtifactsController < ApplicationController
   skip_before_filter :verify_authenticity_token
-
+  
   def create
     @build_artifact = BuildArtifact.new
     @build_artifact.build_attempt_id = params[:build_attempt_id]
@@ -13,5 +13,17 @@ class BuildArtifactsController < ApplicationController
         format.xml  { render :xml => @build_artifact.errors, :status => :unprocessable_entity }
       end
     end
+  end
+
+  def show
+    @project = Project.find_by_name!(params[:project_id])
+    @build = @project.builds.find(params[:build_id])
+    @build_part = @build.build_parts.find(params[:part_id])
+    @build_artifact = BuildArtifact.find(params[:id])
+    @log_output = @build_artifact.log_contents.gsub("\n", '<br />')
+  end
+
+  def handle_escaped(rawtext)
+    ansi_escaped(h(rawtext), 128938214124).html_safe
   end
 end

--- a/app/models/build_artifact.rb
+++ b/app/models/build_artifact.rb
@@ -8,4 +8,12 @@ class BuildArtifact < ActiveRecord::Base
   scope :stdout_log, -> { where(:log_file => ['stdout.log.gz', 'stdout.log']) }
   scope :junit_log, -> { where(:log_file => 'rspec.xml.log.gz') }
   scope :error_txt, -> { where(:log_file => 'error.txt') }
+
+  def log_contents
+    if log_file.path.include? '.gz'
+      Zlib::GzipReader.new(open(log_file.path)).read
+    else
+      log_file.read
+    end
+  end
 end

--- a/app/views/build_artifacts/show.html.haml
+++ b/app/views/build_artifacts/show.html.haml
@@ -1,0 +1,27 @@
+= content_for :title do
+  = @build.ref[0, 7]
+  &ndash;
+  = @build.project.name
+= content_for :favicon do
+  = favicon_link_tag image_path("#{@build_part.to_color}.png"), :type => 'image/png'
+
+%h2.subheader
+  - unless @build.project.main?
+    - if main_project = @build.project.repository.main_project
+      = link_to main_project.name, main_project
+      &ndash;
+  = link_to(@build.project.name, project_path(@build.project))
+  &ndash;
+  = link_to project_build_path(@project, @build) do
+    %code.build-status{ class: @build.state, title: @build.ref }
+      = @build.ref[0, 7]
+  &ndash; Part #{link_to @build_part.id,project_build_part_path(@project, @build, @build_part.id)} - #{File.basename(@build_artifact.log_file.to_s)}
+
+.build-info.build-info-subheader
+  %span.info
+    %span.status{:class => 'build-part-' + @build_part.status.to_s}= @build_part.status.to_s.capitalize
+    on
+    %span.queue #{@build_part.queue} queue
+
+%div#log_output
+  = @log_output.html_safe

--- a/app/views/build_parts/show.html.haml
+++ b/app/views/build_parts/show.html.haml
@@ -50,6 +50,7 @@
         %td
           - attempt.build_artifacts.each do |artifact|
             = link_to File.basename(artifact.log_file.to_s), artifact.log_file.url
+            = link_to "view", project_build_part_artifact_path( @project, @build, @build_part, artifact )
             %br
         %td
           - if attempt.unsuccessful? && @build_part.unsuccessful?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Kochiku::Application.routes.draw do
       post 'rebuild-failed-parts', :action => "rebuild_failed_parts", :on => :member, :as => :rebuild_failed_parts
       resources :build_parts, :as => 'parts', :path => 'parts', :only => [:show] do
         post 'rebuild', :on => :member
+        resources :build_artifacts, :as => 'artifacts', :path => 'artifacts', :only => [:show] 
       end
     end
   end

--- a/spec/models/build_artifact_spec.rb
+++ b/spec/models/build_artifact_spec.rb
@@ -20,4 +20,20 @@ describe BuildArtifact do
       should include(junit_artifact)
     end
   end
+
+  describe "#log_contents" do
+    let!(:artifact)       { FactoryGirl.create :build_artifact }
+    let!(:artifact_gz) { FactoryGirl.create :build_artifact, :log_file => File.open(FIXTURE_PATH + 'stdout.log.gz') }    
+
+    it "should return the log contents for a log" do
+      log_contents = artifact.log_file.read
+      expect(artifact.log_contents).to eq(log_contents)
+    end
+
+    it "should return the log contents for a gzipped log" do
+      infile = open(artifact_gz.log_file.path)
+      log_contents = Zlib::GzipReader.new(infile).read
+      expect(artifact_gz.log_contents).to eq(log_contents)
+    end
+  end
 end


### PR DESCRIPTION
Includes a new "view" link next to the log download link in the build part view that links to a build artifact view that displays the log contents in the browser.

Thanks!,
Eliot