### PR TITLE
Add null => false to timestamp columns

### DIFF
--- a/db/migrate/20110621212000_create_schema.rb
+++ b/db/migrate/20110621212000_create_schema.rb
@@ -5,7 +5,7 @@ class CreateSchema < ActiveRecord::Migration
       t.string :state
       t.string :queue
 
-      t.timestamps
+      t.timestamps(null: false)
     end
 
     create_table :build_parts do |t|
@@ -13,7 +13,7 @@ class CreateSchema < ActiveRecord::Migration
       t.string :kind
       t.text :paths
 
-      t.timestamps
+      t.timestamps(null: false)
     end
 
     create_table :build_part_results do |t|
@@ -23,7 +23,7 @@ class CreateSchema < ActiveRecord::Migration
       t.string :builder
       t.string :result
 
-      t.timestamps
+      t.timestamps(null: false)
     end
 
     create_table :build_artifacts do |t|
@@ -31,7 +31,7 @@ class CreateSchema < ActiveRecord::Migration
       t.string :type
       t.text :content
 
-      t.timestamps
+      t.timestamps(null: false)
     end
 
   end

--- a/db/migrate/20110719204508_create_projects.rb
+++ b/db/migrate/20110719204508_create_projects.rb
@@ -4,7 +4,7 @@ class CreateProjects < ActiveRecord::Migration
       t.string :name
       t.string :branch
 
-      t.timestamps
+      t.timestamps(null: false)
     end
     add_index :projects, [:name, :branch]
   end

--- a/db/migrate/20121008211955_create_repositories.rb
+++ b/db/migrate/20121008211955_create_repositories.rb
@@ -4,7 +4,7 @@ class CreateRepositories < ActiveRecord::Migration
       t.string :url
       t.string :test_command
       t.text :options
-      t.timestamps
+      t.timestamps(null: false)
     end
     add_index :repositories, :url
     add_column :projects, :repository_id, :integer


### PR DESCRIPTION
Prior to Rails 4, timestamp columns were created as not nullable.  [Rails 4 reverted this behavior](https://github.com/rails/rails/commit/fcef728) to be not null be default. Kochiku started as a Rails 3 app and migrated to Rails 4 so databases that were created after the switch to Rails 4 do not have the not null constraint. This migration adds it for all preexisting tables.
