### PR TITLE
Remove Repository command_flag and Build target_name

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -94,7 +94,7 @@ class RepositoriesController < ApplicationController
 
   def repository_params
     params.require(:repository).
-      permit(:url, :repository_name, :test_command, :command_flag, :timeout,
+      permit(:url, :repository_name, :test_command, :timeout,
              :build_pull_requests, :run_ci, :on_green_update,
              :on_success_note, :on_success_script,
              :send_build_failure_email, :allows_kochiku_merges)

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -56,10 +56,8 @@ class Build < ActiveRecord::Base
   scope :completed, -> { where(state: TERMINAL_STATES) }
   scope :successful_for_project, lambda { |project_id| where(:project_id => project_id, :state => :succeeded) }
 
-  def test_command(run_list)
-    command = repository.test_command
-    command += " #{repository.command_flag}" unless run_list.include?(target_name)
-    command
+  def test_command
+    repository.test_command
   end
 
   def previous_successful_build

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -33,7 +33,7 @@ class BuildPart < ActiveRecord::Base
         "branch" => build_instance.branch,
         "test_files" => paths,
         "repo_name" => project.repository.repo_cache_name,
-        "test_command" => build_instance.test_command(paths),
+        "test_command" => build_instance.test_command,
         "repo_url" => project.repository.url_for_fetching,
         "remote_name" => "origin",
         "timeout" => project.repository.timeout.minutes,

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -10,9 +10,6 @@
     %label{:for => "test_command"} Test Command:
     = f.text_field :test_command, {:placeholder => 'e.g. script/ci', :autocapitalize => 'off', :autocorrect => 'off', :spellcheck => 'false'}
   %div
-    %label{:for => "command_flag"} Command Flag:
-    = f.text_field :command_flag, {:placeholder => '', :autocapitalize => 'off', :autocorrect => 'off', :spellcheck => 'false'}
-  %div
     %label{:for => "timeout"} Timeout a build part after:
     = f.text_field :timeout, {:id => "timeout"}
     minutes

--- a/db/migrate/20140415011144_remove_command_flag_from_repositories.rb
+++ b/db/migrate/20140415011144_remove_command_flag_from_repositories.rb
@@ -1,0 +1,6 @@
+class RemoveCommandFlagFromRepositories < ActiveRecord::Migration
+  def change
+    remove_column :repositories, :command_flag, :string
+    remove_column :builds,       :target_name,  :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140415001051) do
+ActiveRecord::Schema.define(version: 20140415011144) do
 
   create_table "build_artifacts", force: true do |t|
     t.integer  "build_attempt_id"
@@ -56,7 +56,6 @@ ActiveRecord::Schema.define(version: 20140415001051) do
     t.integer  "project_id"
     t.boolean  "merge_on_success"
     t.string   "branch"
-    t.string   "target_name"
     t.boolean  "build_failure_email_sent"
     t.boolean  "promoted"
     t.string   "on_success_script_log_file"
@@ -87,7 +86,6 @@ ActiveRecord::Schema.define(version: 20140415001051) do
     t.boolean  "build_pull_requests"
     t.string   "on_green_update"
     t.string   "repo_cache_dir"
-    t.string   "command_flag"
     t.boolean  "send_build_failure_email",    default: true
     t.string   "on_success_script"
     t.integer  "timeout",                     default: 40

--- a/script/kochiku-build.sh.sample
+++ b/script/kochiku-build.sh.sample
@@ -22,10 +22,6 @@ if ARGV.delete("--merge")
   auto_merge = "1"
 end
 
-if project_index = ARGV.index("--project")
-  target_name = ARGV[project_index + 1]
-  ARGV.slice!(project_index, 2)
-end
 # If a ref is given as an argument, use that. Otherwise use the current commit
 if ARGV[0]
   commit_ish = Shellwords.escape(ARGV[0])
@@ -58,7 +54,6 @@ params = {
   'build[branch]' => branch,
   'auto_merge' => auto_merge,
   'repo_url' => repo_url,
-  'build[target_name]' => target_name,
 }
 
 http = Net::HTTP.new(uri.host, uri.port)

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -117,7 +117,6 @@ describe RepositoriesController do
       :url,
       :test_command,
       :on_green_update,
-      :command_flag,
       :on_success_script,
       :on_success_note,
       :repository_name

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -5,22 +5,6 @@ describe Build do
   let(:build) { FactoryGirl.create(:build, :project => project) }
   let(:parts) { [{'type' => 'cucumber', 'files' => ['a', 'b'], 'queue' => 'ci'}, {'type' => 'rspec', 'files' => ['c', 'd'], 'queue' => 'ci'}] }
 
-  describe "#test_command" do
-    before do
-      project.repository.update_attributes!(:command_flag => "-Dsquareup.fastTestsOnly")
-    end
-    it "does not append a custom flag" do
-      build.target_name = "foo"
-      command = build.test_command(["foo"])
-      expect(command).not_to include("-Dsquareup.fastTestsOnly")
-    end
-    it "a custom arg is appended" do
-      build.target_name = nil
-      command = build.test_command(["foo"])
-      expect(command).to include("-Dsquareup.fastTestsOnly")
-    end
-  end
-
   describe "validations" do
     it "requires a ref to be set" do
       build.ref = nil


### PR DESCRIPTION
Command flag should not longer be used and `target_name` only existed to support command_flag.

If you are using command flag, you should add the flag to your Repository's `test_command`.

to: @nolman 
