### PR TITLE
Unique index on Build ref column

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'httparty'
 
 gem 'bullet'
 gem 'pry-rails'
+gem 'pry-byebug'
 
 gem 'colorize', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,9 @@ GEM
     bullet (4.7.1)
       activesupport
       uniform_notifier (>= 1.4.0)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
     capistrano (2.15.5)
       highline
       net-scp (>= 1.0.0)
@@ -69,6 +72,7 @@ GEM
       execjs
     coffee-script-source (1.7.0)
     colorize (0.6.0)
+    columnize (0.8.9)
     compass (0.12.2)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
@@ -79,6 +83,7 @@ GEM
       safe_yaml (~> 1.0.0)
     daemon_controller (1.1.8)
     daemons (1.1.9)
+    debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     draper (1.3.0)
       actionpack (>= 3.0)
@@ -144,6 +149,9 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
     quiet_assets (1.0.2)
@@ -304,6 +312,7 @@ DEPENDENCIES
   mysql2
   nokogiri
   passenger (~> 4.0.10)
+  pry-byebug
   pry-rails
   quiet_assets
   rails (~> 4.0.2)

--- a/app/controllers/pull_requests_controller.rb
+++ b/app/controllers/pull_requests_controller.rb
@@ -29,7 +29,7 @@ class PullRequestsController < ApplicationController
     repository = Repository.find_by_url(payload['repository']['ssh_url'])
     return unless repository
     project = repository.projects.where(name: repository.repository_name + "-pull_requests").first_or_create
-    if active_pull_request? && (build_requested_for_pull_request? || repository.build_pull_requests)
+    if active_pull_request? && repository.build_pull_requests
       sha = payload["pull_request"]["head"]["sha"]
       branch = payload["pull_request"]["head"]["ref"]
 
@@ -39,10 +39,6 @@ class PullRequestsController < ApplicationController
 
   def active_pull_request?
     payload['action'] && payload['action'] != "closed"
-  end
-
-  def build_requested_for_pull_request?
-    payload["pull_request"] && payload["pull_request"]["body"].to_s.downcase.include?("!buildme")
   end
 
   def payload

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -46,9 +46,11 @@ class Build < ActiveRecord::Base
   symbolize :state, :in => STATES
   serialize :error_details, Hash
 
-  validates_presence_of :project_id
-  validates_presence_of :ref
-  validates_uniqueness_of :ref, :scope => :project_id
+  validates :project_id, presence: true
+  validates :ref, presence: true,
+                  length: { is: 40, allow_blank: true },
+                  uniqueness: { scope: :project_id, allow_blank: true }
+
   mount_uploader :on_success_script_log_file, OnSuccessUploader
 
   after_commit :enqueue_partitioning_job, :on => :create

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -81,6 +81,15 @@ class Repository < ActiveRecord::Base
     on_success_note.to_s.strip.present?
   end
 
+  # Public: attempts to lookup a build for the commit under any of the
+  # repository's projects. This is done as an optimization since the contents
+  # of the commit are guaranteed to not have changed.
+  #
+  # Returns: Build AR object or nil
+  def build_for_commit(sha)
+    Build.joins(:project).where(:ref => sha, 'projects.repository_id' => self.id).first
+  end
+
   def project_params
     Repository.project_params(url)
   end

--- a/db/migrate/20140506012721_unique_index_on_builds_ref.rb
+++ b/db/migrate/20140506012721_unique_index_on_builds_ref.rb
@@ -1,0 +1,18 @@
+class UniqueIndexOnBuildsRef < ActiveRecord::Migration
+  def up
+    remove_index :builds, column: :ref
+
+    # set length to 40 characters and add not null constraint
+    change_column :builds, :ref, :string, { limit: 40, null: false }
+
+    add_index :builds, [:ref, :project_id], :unique => true
+  end
+
+  def down
+    remove_index :builds, column: [:ref, :project_id]
+
+    change_column :builds, :ref, :string
+
+    add_index :builds, :ref
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140415011144) do
+ActiveRecord::Schema.define(version: 20140506012721) do
 
   create_table "build_artifacts", force: true do |t|
     t.integer  "build_attempt_id"
@@ -49,10 +49,10 @@ ActiveRecord::Schema.define(version: 20140415011144) do
   add_index "build_parts", ["paths"], name: "index_build_parts_on_paths", length: {"paths"=>255}, using: :btree
 
   create_table "builds", force: true do |t|
-    t.string   "ref"
+    t.string   "ref",                        limit: 40, null: false
     t.string   "state"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.integer  "project_id"
     t.boolean  "merge_on_success"
     t.string   "branch"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 20140415011144) do
   end
 
   add_index "builds", ["project_id"], name: "index_builds_on_project_id", using: :btree
-  add_index "builds", ["ref"], name: "index_builds_on_ref", using: :btree
+  add_index "builds", ["ref", "project_id"], name: "index_builds_on_ref_and_project_id", unique: true, using: :btree
 
   create_table "projects", force: true do |t|
     t.string   "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,7 +56,7 @@ end
 
 def create_build(project, test_types, build_attempt_state: :passed)
   build = Build.create!(:project => project,
-                        :ref => SecureRandom.hex,
+                        :ref => SecureRandom.hex(20),
                         :state => :runnable)
 
   Array(test_types).each do |kind|

--- a/spec/controllers/pull_requests_controller_spec.rb
+++ b/spec/controllers/pull_requests_controller_spec.rb
@@ -43,7 +43,7 @@ describe PullRequestsController do
           }.to change(Build, :count).by(1)
           build = Build.last
           expect(build.branch).to eq("master")
-          expect(build.ref).to eq("SOME-SHA1")
+          expect(build.ref).to eq(to_40('2'))
         end
 
         it "does not a build for not master" do
@@ -62,10 +62,10 @@ describe PullRequestsController do
         end
 
         it "does not build if there is an active ci build" do
-          project.builds.create!(:ref => "sha", :state => :succeeded, :branch => 'master')
+          project.builds.create!(:ref => to_40('w'), :state => :succeeded, :branch => 'master')
           frozen_time = 3.seconds.from_now
           allow(Time).to receive(:now).and_return(frozen_time)
-          project.builds.create!(:ref => "sha2", :state => :partitioning, :branch => 'master')
+          project.builds.create!(:ref => to_40('y'), :state => :partitioning, :branch => 'master')
           expect {
             post :build, 'payload' => push_payload
             expect(response).to be_success
@@ -73,7 +73,7 @@ describe PullRequestsController do
         end
 
         it "builds if there is completed ci build" do
-          project.builds.create!(:ref => "sha", :state => :succeeded, :branch => 'master')
+          project.builds.create!(:ref => to_40('w'), :state => :succeeded, :branch => 'master')
           expect {
             post :build, 'payload' => push_payload
             expect(response).to be_success
@@ -81,10 +81,10 @@ describe PullRequestsController do
         end
 
         it "builds if there is a completed ci build after a build that is still building" do
-          project.builds.create!(:ref => "sha", :state => :partitioning, :branch => 'master')
+          project.builds.create!(:ref => to_40('w'), :state => :partitioning, :branch => 'master')
           frozen_time = 3.seconds.from_now
           allow(Time).to receive(:now).and_return(frozen_time)
-          project.builds.create!(:ref => "sha2", :state => :succeeded, :branch => 'master')
+          project.builds.create!(:ref => to_40('y'), :state => :succeeded, :branch => 'master')
           expect {
             post :build, 'payload' => push_payload
             expect(response).to be_success
@@ -100,6 +100,10 @@ describe PullRequestsController do
       end
 
       context "for pull requests" do
+        before do
+          repository.update_attribute(:build_pull_requests, true)
+        end
+
         it "creates the pull request project" do
           expect {
             post :build, 'payload' => pull_request_payload
@@ -116,14 +120,12 @@ describe PullRequestsController do
           }.to change(Build, :count).by(1)
           build = Build.last
           expect(build.branch).to eq("branch-name")
-          expect(build.ref).to eq("Some-sha")
+          expect(build.ref).to eq(to_40('1'))
         end
 
         it "will enqueue a build if autobuild pull requests is enabled" do
-          repository.build_pull_requests = "1"
-          repository.save!
           github_payload = pull_request_payload("pull_request" => {
-            "head" => {"sha" => "Some-sha", "ref" => "branch-name"},
+            "head" => {"sha" => to_40('1'), "ref" => "branch-name"},
             "body" => "best pull request ever",
           })
           expect {
@@ -134,8 +136,6 @@ describe PullRequestsController do
 
         context "when the pull request sha has already been built" do
           before do
-            repository.build_pull_requests = "1"
-            repository.save!
             @github_payload = pull_request_payload("pull_request" => {
               "head" => {"sha" => "de8251ff97ee194a289832576287d6f8ad74e3d0", "ref" => "branch-name"},
               "body" => "best pull request ever",
@@ -151,13 +151,13 @@ describe PullRequestsController do
             }.to_not change(Build, :count)
           end
 
-          it "rebuilds if the sha is on a different repo" do
+          it "still creates a build if the sha is used by a different repo" do
             project = FactoryGirl.create(:project)
-            build = FactoryGirl.create(:build, :project => project, :ref => "de8251ff97ee194a289832576287d6f8ad74e3d0")
+            FactoryGirl.create(:build, project: project, ref: "de8251ff97ee194a289832576287d6f8ad74e3d0")
+
             expect {
               post :build, 'payload' => @github_payload
-              expect(response).to be_success
-            }.to change(Build, :count)
+            }.to change(Build, :count).by(1)
           end
         end
 
@@ -165,17 +165,11 @@ describe PullRequestsController do
           let(:project) { FactoryGirl.create(:project, :name => "web-pull_requests", :repository => repository) }
 
           it "does not create a pull request if not requested" do
+            repository.update_attribute(:build_pull_requests, false)
             expect {
               post :build, 'payload' => pull_request_payload({"pull_request" => {"body" => "don't build it"}})
               expect(response).to be_success
             }.to_not change(project.builds, :count)
-          end
-
-          it "ignores !buildme casing" do
-            expect {
-              post :build, 'payload' => pull_request_payload({"pull_request" => {"body" => "!BuIlDMe"}})
-              expect(response).to be_success
-            }.to change(project.builds, :count).by(1)
           end
 
           it "does not build a closed pull request" do
@@ -192,17 +186,16 @@ describe PullRequestsController do
 
           context "when there are other builds for the same branch" do
             let(:branch_name) { "test-branch" }
-            let!(:build_one) { FactoryGirl.create(:build, :project => project, :branch => branch_name, :ref => "11deadbeef11") }
-            let!(:build_two) { FactoryGirl.create(:build, :project => project, :branch => branch_name, :ref => "22deadbeef22") }
+            let!(:build_one) { FactoryGirl.create(:build, :project => project, :branch => branch_name, :ref => to_40('w')) }
+            let!(:build_two) { FactoryGirl.create(:build, :project => project, :branch => branch_name, :ref => to_40('y')) }
 
             before do
-              repository.build_pull_requests = "1"
-              repository.save!
+              repository.update_attribute(:build_pull_requests, true)
             end
 
             it "aborts previous builds of the same branch" do
               github_payload = pull_request_payload("pull_request" => {
-                  "head" => {"sha" => "Some-sha", "ref" => branch_name},
+                  "head" => {"sha" => to_40('z'), "ref" => branch_name},
                   "body" => "best pull request ever",
               })
 
@@ -238,10 +231,10 @@ describe PullRequestsController do
     {
       "pull_request" => {
         "head" => {
-          "sha" => "Some-sha",
+          "sha" => to_40('1'),
           "ref" => "branch-name"
         },
-        "body" => "best pull request ever !BUILDME",
+        "body" => "best pull request ever",
         "title" => "this is a pull request",
       },
       "repository" => {
@@ -253,7 +246,7 @@ describe PullRequestsController do
 
   def push_payload(options = {})
     {
-      "after" => "SOME-SHA1",
+      "after" => to_40('2'),
       "repository" => {
         "url" => "https://git.example.com/square/web",
       },

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -164,35 +164,36 @@ describe RepositoriesController do
   describe 'post /build-ref' do
     let(:repository) { FactoryGirl.create(:repository) }
     let(:repo_name) { repository.repository_name }
+    let(:fake_sha) { to_40('1') }
 
     it "creates a master build with query string parameters" do
-      post :build_ref, id: repository.to_param, ref: 'master', sha: 'abc123'
+      post :build_ref, id: repository.to_param, ref: 'master', sha: fake_sha
 
-      verify_response_creates_build response, 'master', 'abc123', repo_name
+      verify_response_creates_build response, 'master', fake_sha, repo_name
     end
 
     it "creates a master build with payload" do
-      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/master', toHash: 'abc123'}]
+      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/master', toHash: fake_sha}]
 
-      verify_response_creates_build response, 'master', 'abc123', repo_name
+      verify_response_creates_build response, 'master', fake_sha, repo_name
     end
 
     it "creates a PR build with query string parameters" do
-      post :build_ref, id: repository.to_param, ref: 'blah', sha: 'abc123'
+      post :build_ref, id: repository.to_param, ref: 'blah', sha: fake_sha
 
-      verify_response_creates_build response, 'blah', 'abc123', repo_name + "-pull_requests"
+      verify_response_creates_build response, 'blah', fake_sha, repo_name + "-pull_requests"
     end
 
     it "creates a PR build with payload" do
-      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/blah', toHash: 'abc123'}]
+      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/blah', toHash: fake_sha}]
 
-      verify_response_creates_build response, 'blah', 'abc123', repo_name + "-pull_requests"
+      verify_response_creates_build response, 'blah', fake_sha, repo_name + "-pull_requests"
     end
 
     it "creates a PR build with payload" do
-      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/blah/with/a/slash', toHash: 'abc123'}]
+      post :build_ref, id: repository.to_param, refChanges: [{refId: 'refs/heads/blah/with/a/slash', toHash: fake_sha}]
 
-      verify_response_creates_build response, 'blah/with/a/slash', 'abc123', repo_name + "-pull_requests"
+      verify_response_creates_build response, 'blah/with/a/slash', fake_sha, repo_name + "-pull_requests"
     end
 
     def verify_response_creates_build(response, branch, ref, repo_name)

--- a/spec/jobs/build_state_update_job_spec.rb
+++ b/spec/jobs/build_state_update_job_spec.rb
@@ -68,12 +68,12 @@ describe BuildStateUpdateJob do
           let(:name) { repository.repository_name }
 
           context "new sha is available" do
-            let(:current_repo_master) { "new-sha" }
+            let(:current_repo_master) { "new-sha-11111111111111111111111111111111" }
 
             it "builds when there is a new sha to build" do
               expect { subject }.to change(project.builds, :count).by(1)
               build = project.builds.last
-              expect(build.ref).to eq("new-sha")
+              expect(build.ref).to eq(current_repo_master)
             end
 
             # TODO: this shouldn't be under the "when all parts have passed" context
@@ -86,11 +86,11 @@ describe BuildStateUpdateJob do
               build.build_parts.first.create_and_enqueue_new_build_attempt!
               expect { subject }.to change(project.builds, :count).by(1)
               build = project.builds.last
-              expect(build.ref).to eq("new-sha")
+              expect(build.ref).to eq(current_repo_master)
             end
 
             it "does not kick off a new build if one is already running" do
-              project.builds.create!(:ref => 'some-other-sha', :state => :partitioning, :branch => 'master')
+              project.builds.create!(:ref => 'some-other-sha-1111111111111111111111111', :state => :partitioning, :branch => 'master')
               expect { subject }.to_not change(project.builds, :count)
             end
 

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -18,7 +18,7 @@ describe Build do
       expect(build).to have(1).error_on(:project_id)
     end
 
-    it "should force uniqueness on project_id and ref pairs" do
+    it "should force uniqueness on ref" do
       build2 = FactoryGirl.build(:build, :project => project, :ref => build.ref)
       expect(build2).not_to be_valid
       expect(build2).to have(1).error_on(:ref)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,8 +5,8 @@ describe Project do
     let(:project) { FactoryGirl.create(:project) }
 
     it 'creates a new build only if one does not exist' do
-      build1 = project.ensure_master_build_exists('abc123')
-      build2 = project.ensure_master_build_exists('abc123')
+      build1 = project.ensure_master_build_exists(to_40('abcdef'))
+      build2 = project.ensure_master_build_exists(to_40('abcdef'))
       expect(build1).not_to eq(nil)
       expect(build1).to eq(build2)
     end
@@ -16,24 +16,25 @@ describe Project do
     let(:project) { FactoryGirl.create(:project) }
 
     it 'creates a new build only if one does not exist' do
-      build1 = project.ensure_branch_build_exists('mybranch', 'abc123')
-      build2 = project.ensure_branch_build_exists('mybranch', 'abc123')
+      build1 = project.ensure_branch_build_exists('mybranch', to_40('abcdef'))
+      build2 = project.ensure_branch_build_exists('mybranch', to_40('abcdef'))
       expect(build1).not_to eq(nil)
       expect(build1).to eq(build2)
+      expect(build1.branch).to eq('mybranch')
     end
 
     it 'aborts previous builds if the current build is a new build' do
-      build1 = project.ensure_branch_build_exists('mybranch', 'abc123')
-      build2 = project.ensure_branch_build_exists('mybranch', 'def456')
+      build1 = project.ensure_branch_build_exists('mybranch', '2df46538332f4f3216b5bfa015ecc39e63d5e725')
+      build2 = project.ensure_branch_build_exists('mybranch', '4025f76f8a6b2a31431caf4f1a9074675fefc641')
       expect(build1.reload).to be_aborted
       expect(build2.reload).not_to be_aborted
     end
 
     it 'does abort build if the build is already running' do
-      build1 = project.ensure_branch_build_exists('mybranch', 'abc123')
+      build1 = project.ensure_branch_build_exists('mybranch', to_40('abcdef'))
       expect(build1.reload).not_to be_aborted
 
-      build2 = project.ensure_branch_build_exists('mybranch', 'abc123')
+      build2 = project.ensure_branch_build_exists('mybranch', to_40('abcdef'))
       expect(build2.reload).not_to be_aborted
 
       expect(build1).not_to be_aborted
@@ -45,9 +46,9 @@ describe Project do
     let(:project) { FactoryGirl.create(:project) }
 
     it 'aborts non-finished builds for a branch' do
-      build1 = project.ensure_branch_build_exists('mybranch', 'abc123')
-      build2 = project.ensure_branch_build_exists('mybranch', 'efg456')
-      build3 = project.ensure_branch_build_exists('mybranch', 'hij789')
+      build1 = project.ensure_branch_build_exists('mybranch', to_40('1'))
+      build2 = project.ensure_branch_build_exists('mybranch', to_40('2'))
+      build3 = project.ensure_branch_build_exists('mybranch', to_40('3'))
       build1.state = :succeeded
       build1.save!
 

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -245,4 +245,24 @@ describe Repository do
     end
 
   end
+
+  describe '#build_for_commit' do
+    let!(:repositoryA) { FactoryGirl.create(:repository) }
+    let!(:projectA1) { FactoryGirl.create(:project, repository: repositoryA) }
+    let!(:repositoryB) { FactoryGirl.create(:repository) }
+    let!(:buildA1) { FactoryGirl.create(:build, project: projectA1, ref: sha) }
+    let(:sha) { to_40('a') }
+
+    context 'a build for the sha exists under this repository' do
+      it 'should return an existing build with the same sha' do
+        expect(repositoryA.build_for_commit(sha)).to eq(buildA1)
+      end
+    end
+
+    context 'a build exists under a different repository' do
+      it 'should return nil' do
+        expect(repositoryB.build_for_commit(sha)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
   factory :build do
     project
     state :partitioning
-    ref { SecureRandom.hex }
+    ref { SecureRandom.hex(20) } # 20 is the length in bytes, resulting string is twice n
 
     factory :main_project_build do
       association :project, :factory => :main_project

--- a/spec/support/sha_helper.rb
+++ b/spec/support/sha_helper.rb
@@ -1,0 +1,4 @@
+def to_40(short)
+  multiplier = (40.0 / short.length).ceil
+  (short * multiplier).slice(0, 40)
+end


### PR DESCRIPTION
This is being added to prevent the race condition of multiple build requests for the same sha.
- constrain the ref column to 40 characters (the length of a SHA-1)
- Many changes to tests to account for new constraint in test data
- Removed undocumented '!buildme' feature from PullRequests controller since that was superceded by build_pull_requests option on Repository.
- add pry-byebug to Gemfile

To: @cheister @square/kochiku-contributors 
