### PR TITLE
Swap the remote in-place instead of blowing away the cache dir

### DIFF
--- a/spec/jobs/build_state_update_job_spec.rb
+++ b/spec/jobs/build_state_update_job_spec.rb
@@ -13,7 +13,7 @@ describe BuildStateUpdateJob do
     # TODO: This is terrible, need to fold this feedback back into the design.
     # We are stubbing methods that are not called from the class under test.
     allow(GitRepo).to receive(:run!)
-    allow(GitRepo).to receive(:valid_remote_url?).and_return(true)
+    allow(GitRepo).to receive(:harmonize_remote_url)
     allow(GitRepo).to receive(:synchronize_with_remote).and_return(true)
     allow(GitRepo).to receive(:sha_for_branch).and_return(current_repo_master)
     allow(BuildStrategy).to receive(:promote_build)


### PR DESCRIPTION
Sister PR to [kochiku-worker#15](https://github.com/square/kochiku-worker/pull/15).
