### PR TITLE
Update URL_PARSERS to allow periods in names

### DIFF
--- a/lib/remote_server/github.rb
+++ b/lib/remote_server/github.rb
@@ -7,9 +7,9 @@ module RemoteServer
   # All integration with Github must go via this class.
   class Github
     URL_PARSERS = [
-      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[^.]+)\.?},         # git@
-      %r{\Agit://(?<host>.*)/(?<username>.*)/(?<name>[^.]+)\.git},     # git://  (GHE only)
-      %r{\Ahttps?://(?<host>.*)/(?<username>.*)/(?<name>[^.]+)\.?},    # https://
+      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[-.\w]+?)(\.git)?\z},       # git@
+      %r{\Agit://(?<host>.*)/(?<username>.*)/(?<name>[-.\w]+)\.git\z},         # git://  (GHE only)
+      %r{\Ahttps?://(?<host>.*)/(?<username>.*)/(?<name>[-.\w]+?)(\.git)?\z},  # https://
     ]
 
     def initialize(url)

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -7,9 +7,9 @@ module RemoteServer
     attr_reader :stash_request
 
     URL_PARSERS = [
-      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[^.]+)\.git\z},
-      %r{\Assh://git@(?<host>.*?)(?<port>:\d+)?/(?<username>.*)/(?<name>[^.]+)\.git\z},
-      %r{\Ahttps://(?<host>[^@]+)/scm/(?<username>.+)/(?<name>[^.]+)\.git\z},
+      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[-.\w]+)\.git\z},
+      %r{\Assh://git@(?<host>.*?)(?<port>:\d+)?/(?<username>.*)/(?<name>[-.\w]+)\.git\z},
+      %r{\Ahttps://(?<host>[^@]+)/scm/(?<username>.+)/(?<name>[-.\w]+)\.git\z},
     ]
 
     def initialize(url)

--- a/spec/lib/remote_server/stash_spec.rb
+++ b/spec/lib/remote_server/stash_spec.rb
@@ -98,6 +98,33 @@ describe RemoteServer::Stash do
         port:                 '7999'
       )
     end
+
+    it 'should allow periods, hyphens, and underscores in repository names' do
+      result = described_class.new("git@stash.example.com:angular/an-gu_lar.js.git")
+      expect(result.attributes[:repository_name]).to eq('an-gu_lar.js')
+
+      result = described_class.new("ssh://git@stash.example.com/angular/an-gu_lar.js.git")
+      expect(result.attributes[:repository_name]).to eq('an-gu_lar.js')
+
+      result = described_class.new("https://stash.example.com/scm/angular/an-gu_lar.js.git")
+      expect(result.attributes[:repository_name]).to eq('an-gu_lar.js')
+    end
+
+    it 'should not allow characters disallowed by Github in repository names' do
+      %w(! @ # $ % ^ & * ( ) = + \ | ` ~ [ ] { } : ; ' " ?).each do |symbol|
+        expect {
+          described_class.new("git@stash.example.com:angular/bad#{symbol}name.git")
+        }.to raise_error(RemoteServer::UnknownUrlFormat)
+
+        expect {
+          described_class.new("ssh://git@stash.example.com/angular/bad#{symbol}name.git")
+        }.to raise_error(RemoteServer::UnknownUrlFormat)
+
+        expect {
+          described_class.new("https://stash.example.com/scm/angular/bad#{symbol}name.git")
+        }.to raise_error(RemoteServer::UnknownUrlFormat)
+      end
+    end
   end
 
   describe "#canonical_repository_url" do


### PR DESCRIPTION
Update URL_PARSERS to allow periods in names and disallow unwanted special characters. The square-connector.js project uncovered this deficiency.
