### PR TITLE
Builds that fail in under a minute reattempted

### DIFF
--- a/app/models/build_attempt.rb
+++ b/app/models/build_attempt.rb
@@ -71,6 +71,10 @@ class BuildAttempt < ActiveRecord::Base
     state == :running
   end
 
+  def errored?
+    state == :errored
+  end
+
   def should_reattempt?
     unsuccessful? && build_part.should_reattempt?
   end

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -99,8 +99,15 @@ class BuildPart < ActiveRecord::Base
   end
 
   def should_reattempt?
-    (build_attempts.unsuccessful.count - 1) < retry_count &&
+    if (build_attempts.unsuccessful.count - 1) < retry_count &&
         (build_instance.merge_on_success? || build_instance.project.main?)
+      true
+    elsif elapsed_time && elapsed_time < 60 && last_attempt.errored? &&
+        build_attempts.unsuccessful.count < 5
+      true
+    else
+      false
+    end
   end
 
   def last_stdout_artifact

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -265,5 +265,43 @@ describe BuildPart do
         expect(build_part.should_reattempt?).to be true
       end
     end
+
+    context "when it fails very fast" do
+      let(:build_part) { FactoryGirl.create(:build_part, retry_count: 0, build_instance: build) }
+
+      before do
+        FactoryGirl.create(:build_attempt, build_part: build_part, state: :errored, started_at: 10.seconds.ago, finished_at: Time.now)
+      end
+
+      it "will reattempt" do
+        expect(build_part.should_reattempt?).to be true
+      end
+    end
+
+    context "after 5 failures" do
+      let(:build_part) { FactoryGirl.create(:build_part, retry_count: 0, build_instance: build) }
+
+      before do
+        5.times do
+          FactoryGirl.create(:build_attempt, build_part: build_part, state: :errored, started_at: 10.seconds.ago, finished_at: Time.now)
+        end
+      end
+
+      it "not will reattempt" do
+        expect(build_part.should_reattempt?).to be false
+      end
+    end
+
+    context "when it fails after a longer time" do
+      let(:build_part) { FactoryGirl.create(:build_part, retry_count: 0, build_instance: build) }
+
+      before do
+        FactoryGirl.create(:build_attempt, build_part: build_part, state: :errored, started_at: 70.seconds.ago, finished_at: Time.now)
+      end
+
+      it "shouldn't reattempt" do
+        expect(build_part.should_reattempt?).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
Reattempts builds that fail in under a minute the first five times. Includes a few tests for the new behavior.
