### PR TITLE
Prevent Firefox from showing "NaN" values for elapsed times.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,7 +25,7 @@ StartTimes = {};
 Kochiku.delayedRefresh = function(updateInfo) {
   var now = new Date();
   $(updateInfo.table).find('tr:has(.running)').each( function() {
-      var startTime = new Date(Date.parse(StartTimes[$(this).children()[0].innerText]));
+      var startTime = new Date(Date.parse(StartTimes[$(this).data('id')]));
       $(this).find('.elapsed').text(
         Math.round((now-startTime)/60000) + ":" + ("00" + (Math.round((now-startTime)/1000)%60)).slice(-2));
   });

--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -66,7 +66,7 @@
   %tbody
     - @build.build_parts.each do |part|
       - cache(part) do
-        %tr
+        %tr{:"data-id" => part.id}
           %td.right= link_to(part.id, project_build_part_path(@project, @build, part))
           %td
             %span.part-status{:class => part.status}


### PR DESCRIPTION
Firefox does not implement the non-standard `Element#innerText`.

![2014-06-23 at 3 01 pm](https://cloud.githubusercontent.com/assets/1938/3364640/085d9aa2-fb22-11e3-8399-23738bcfdad8.png)
