### PR TITLE
Fixes learned from a bad deploy

### DIFF
--- a/db/migrate/20140617214701_add_success_email.rb
+++ b/db/migrate/20140617214701_add_success_email.rb
@@ -4,11 +4,17 @@ class AddSuccessEmail < ActiveRecord::Migration
     add_column :repositories, :send_build_success_email, :boolean, :default => true, :null => false
     reversible do |dir|
       change_table :builds do |t|
-        dir.up { t.change :build_failure_email_sent, :boolean, :default => false, :null => false }
+        dir.up do
+          execute 'UPDATE builds SET build_failure_email_sent = 0 WHERE build_failure_email_sent IS NULL'
+          t.change :build_failure_email_sent, :boolean, :default => false, :null => false
+        end
         dir.down { t.change :build_failure_email_sent, :boolean, :default => nil, :null => true }
       end
       change_table :repositories do |t|
-        dir.up { t.change :send_build_failure_email, :boolean, :default => true, :null => false }
+        dir.up do
+          execute 'UPDATE repositories SET send_build_failure_email = 1 WHERE send_build_failure_email IS NULL'
+          t.change :send_build_failure_email, :boolean, :default => true, :null => false
+        end
         dir.down { t.change :send_build_failure_email, :boolean, :default => true, :null => true }
       end
     end

--- a/lib/git_blame.rb
+++ b/lib/git_blame.rb
@@ -78,7 +78,7 @@ class GitBlame
     end
 
     def lookup_git_names_and_emails(git_names_and_emails)
-      git_names_and_emails.map do |git_name_and_email|
+      Array(git_names_and_emails).map do |git_name_and_email|
         name, email = git_name_and_email.split(":")
         Array(email_from_git_email(email))
       end.flatten.compact.uniq


### PR DESCRIPTION
The old migration errored because of NULLs in columns that we are disallowing NULL, so those are getting cleaned out now.
