### PR TITLE
Be smarter about how often to search for kochiku.yml

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -75,7 +75,11 @@ class Build < ActiveRecord::Base
   end
 
   def kochiku_yml
-    @kochiku_yml ||= GitRepo.load_kochiku_yml(repository, ref)
+    if @kochiku_yml.nil?
+      @kochiku_yml = GitRepo.load_kochiku_yml(repository, ref) || false
+    else
+      @kochiku_yml
+    end
   end
 
   def partition(parts)

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -29,6 +29,15 @@ describe Build do
     end
   end
 
+  describe '#kochiku_yml' do
+    it 'only tries to load once if it fails' do
+      expect(GitRepo).to receive(:load_kochiku_yml).once
+      5.times do
+        build.kochiku_yml
+      end
+    end
+  end
+
   describe "#partition" do
     it "should create a BuildPart for each path" do
       build.partition(parts)


### PR DESCRIPTION
Anything that didn't have a kochiku.yml was shelling to git multiple times trying to find one.
