### PR TITLE
Remove git notes

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -101,9 +101,8 @@ class RepositoriesController < ApplicationController
 
   def repository_params
     params.require(:repository).
-      permit(:url, :name, :test_command, :timeout,
-             :build_pull_requests, :run_ci, :on_green_update,
-             :on_success_note, :on_success_script,
+      permit(:url, :name, :test_command, :timeout, :build_pull_requests,
+             :run_ci, :on_green_update, :on_success_script,
              :send_build_failure_email, :allows_kochiku_merges)
   end
 end

--- a/app/jobs/build_state_update_job.rb
+++ b/app/jobs/build_state_update_job.rb
@@ -21,9 +21,6 @@ class BuildStateUpdateJob < JobBase
     end
 
     if build.succeeded?
-      if build.repository.has_on_success_note?
-        build.add_note!
-      end
       if build.on_success_script.present? && !build.on_success_script_log_file.present?
         BuildStrategy.run_success_script(build)
       end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -180,10 +180,6 @@ class Build < ActiveRecord::Base
     end
   end
 
-  def add_note!
-    BuildStrategy.add_note(ref, "ci-#{project.name}", repository)
-  end
-
   def completed?
     TERMINAL_STATES.include?(state)
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -67,10 +67,6 @@ class Repository < ActiveRecord::Base
     on_success_script.to_s.strip.present?
   end
 
-  def has_on_success_note?
-    on_success_note.to_s.strip.present?
-  end
-
   # Public: attempts to lookup a build for the commit under any of the
   # repository's projects. This is done as an optimization since the contents
   # of the commit are guaranteed to not have changed.

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -29,9 +29,6 @@
       %label{:for => "on_green_update"} Update branches to last green commit:
       = f.text_field :on_green_update, {:id => "on_green_update", :placeholder => "Comma separated list of branches"}
     %div
-      %label{:for => "on_success_note"} Add git note:
-      = f.text_field :on_success_note, {:id => "on_success_note", :placeholder => "ex. (ci=green)"}
-    %div
       %label{:for => "on_success_script"} Run:
       = f.text_field :on_success_script, {:id => "on_success_script"}
     %div

--- a/db/migrate/20140715225910_remove_notes.rb
+++ b/db/migrate/20140715225910_remove_notes.rb
@@ -1,0 +1,5 @@
+class RemoveNotes < ActiveRecord::Migration
+  def change
+    remove_column :repositories, :on_success_note, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140617214701) do
+ActiveRecord::Schema.define(version: 20140715225910) do
 
   create_table "build_artifacts", force: true do |t|
     t.integer  "build_attempt_id"
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 20140617214701) do
     t.boolean  "send_build_failure_email",    default: true, null: false
     t.string   "on_success_script"
     t.integer  "timeout",                     default: 40
-    t.string   "on_success_note"
     t.string   "name",                                       null: false
     t.boolean  "allows_kochiku_merges",       default: true
     t.string   "host",                                       null: false

--- a/lib/build_strategies/development_build_strategy.rb
+++ b/lib/build_strategies/development_build_strategy.rb
@@ -6,7 +6,5 @@ class BuildStrategy
     end
     def run_success_script(build)
     end
-    def add_note(build_ref, namespace, note)
-    end
   end
 end

--- a/lib/build_strategies/production_build_strategy.rb
+++ b/lib/build_strategies/production_build_strategy.rb
@@ -24,14 +24,6 @@ class BuildStrategy
       end
     end
 
-    def add_note(build_ref, namespace, repository)
-      GitRepo.inside_repo(repository) do
-        Cocaine::CommandLine.new("git", "fetch -f origin refs/notes/*:refs/notes/*").run
-        Cocaine::CommandLine.new("git", "notes --ref=#{namespace} add -f -m '#{repository.on_success_note}' #{build_ref}").run
-        Cocaine::CommandLine.new("git", "push -f origin refs/notes/#{namespace}").run
-      end
-    end
-
     def run_success_script(build)
       GitRepo.inside_copy(build.repository, build.ref) do
         command = Cocaine::CommandLine.new(build.on_success_script, "", :expected_outcodes => 0..255)

--- a/lib/build_strategies/test_build_strategy.rb
+++ b/lib/build_strategies/test_build_strategy.rb
@@ -6,7 +6,5 @@ class BuildStrategy
     end
     def run_success_script(build)
     end
-    def add_note(build_ref, namespace, note)
-    end
   end
 end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -123,7 +123,6 @@ describe RepositoriesController do
       :test_command,
       :on_green_update,
       :on_success_script,
-      :on_success_note,
       :name
     ].each do |attribute|
       it "should successfully update the #{attribute} attribute" do


### PR DESCRIPTION
Workers fail trying to add git notes, and a quick poll showed that nobody is relying on them anymore, so we're going to stop having notes entirely.
