### PR TITLE
Open-sourcing Maven Partitioner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -53,6 +53,7 @@ Kochiku.graphBuildTimes = function(projectName) {
       cucumber:     'hsl(87,  63%, 47%)',
       spec:         'hsl(187, 63%, 47%)',
       jasmine:      'hsl(27,  63%, 47%)',
+      maven:        'hsl(207, 63%, 47%)',
       unit:         'hsl(187, 63%, 47%)',
       integration:  'hsl(87,  63%, 47%)',
       acceptance:   'hsl(207, 63%, 47%)'

--- a/app/jobs/build_partitioning_job.rb
+++ b/app/jobs/build_partitioning_job.rb
@@ -14,7 +14,7 @@ class BuildPartitioningJob < JobBase
   end
 
   def perform
-    @build.partition(Partitioner.new.partitions(@build))
+    @build.partition(Partitioner.for_build(@build).partitions)
     @build.update_commit_status!
   end
 

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -66,6 +66,10 @@ class Build < ActiveRecord::Base
     (kochiku_yml && kochiku_yml.has_key?('on_success_script')) ? kochiku_yml['on_success_script'] : repository.on_success_script
   end
 
+  def previous_build
+    project.builds.order("id DESC").where("id < ?", self.id).first
+  end
+
   def previous_successful_build
     Build.successful_for_project(project_id).order("id DESC").where("id < ?", self.id).first
   end

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -20,9 +20,7 @@ class BuildPart < ActiveRecord::Base
   def create_and_enqueue_new_build_attempt!
     build_attempt = build_attempts.create!(:state => :runnable)
     build_instance.running!
-
     BuildAttemptJob.enqueue_on(queue.to_s, job_args(build_attempt))
-
     build_attempt
   end
 

--- a/app/views/build_mailer/build_break_email.html.erb
+++ b/app/views/build_mailer/build_break_email.html.erb
@@ -20,9 +20,20 @@
         <%= link_to("Part number #{failed_build_part.id}", project_build_part_url(@build.project, @build, failed_build_part)) %>
         failed after <%= failed_build_part.elapsed_time.to_i/60 %> minutes,
         for details you can go directly to the <%= link_to('stdout', failed_build_stdout(failed_build_part)) %>
-    </li>
-    <% end %>
+      <% end %>
     </ul>
+    <br>
+    <% @responsible_email_and_files.each do |email, files| %>
+      <%= email %> was emailed because of changes to:
+      <ul>
+        <% files.each do |file| %>
+          <li>
+          <%= file %>
+        </li>
+      <% end %>
+      </ul>
+    <% end %>
+    <br>
 
     <h2>
       <%= "Changes #{@build.project.main? ? 'since last success' : 'included in build'}" %>
@@ -31,8 +42,8 @@
       <b>SHA: <%= link_to(git_change[:hash], "#{@build.project.repository.remote_server.href_for_commit(git_change[:hash])}") %></b><br>
       <b>Committer:</b> <%= git_change[:author] %><br>
       <b>Date:</b> <%=  git_change[:date] %><br>
-    <pre><%= git_change[:message] %></pre>
-    <br><br>
-  <% end %>
+      <pre><%= git_change[:message] %></pre>
+      <br><br>
+    <% end %>
   </body>
 </html>

--- a/app/views/build_mailer/build_break_email.text.erb
+++ b/app/views/build_mailer/build_break_email.text.erb
@@ -14,6 +14,10 @@ Failed build parts:
 
 <% end %>
 
+<% @responsible_email_and_files.each do |email, files| %>
+  <%= email %> was emailed because of changes to <%= files.join(", ") %>
+<% end %>
+
 --------------------------------------------------------------------------------
 <%= "Changes #{@build.project.main? ? 'since last success' : 'included in build'}" %>
 --------------------------------------------------------------------------------

--- a/lib/git_blame.rb
+++ b/lib/git_blame.rb
@@ -31,6 +31,13 @@ class GitBlame
       parse_git_changes(output)
     end
 
+    def files_changed_since_last_build(build, options = {})
+      output = GitRepo.inside_repo(build.repository) do
+        Cocaine::CommandLine.new("git log --no-merges --format='::!::%an:%ae::!::' --name-only '#{build.previous_build.try(:ref)}...#{build.ref}'").run
+      end
+      parse_git_files_changes(output, options)
+    end
+
     def files_changed_since_last_green(build, options = {})
       output = GitRepo.inside_repo(build.repository) do
         # TODO: Push this down into GitRepo and integration test it.

--- a/lib/git_repo.rb
+++ b/lib/git_repo.rb
@@ -40,6 +40,8 @@ class GitRepo
 
     def load_kochiku_yml(repository, ref)
       inside_repo(repository) do
+        raise RefNotFoundError, "repo:#{repository.url}, sha:#{ref}" unless system("git rev-list --quiet -n1 #{ref}")
+
         read_repo_config(ref)
       end
     end

--- a/lib/partitioner.rb
+++ b/lib/partitioner.rb
@@ -1,189 +1,21 @@
-class Partitioner
+require 'partitioner/base'
+require 'partitioner/maven'
+require 'partitioner/default'
 
-  def partitions(build)
-    GitRepo.inside_copy(build.repository, build.ref) do
-      @kochiku_yml = build.kochiku_yml
-      if @kochiku_yml
-        # Handle old kochiku.yml
-        if @kochiku_yml.is_a?(Array)
-          @kochiku_yml.map { |subset| partitions_for(build, subset) }.flatten
-        else
-          build_partitions(build)
-        end
+module Partitioner
+  def self.for_build(build)
+    kochiku_yml = build.kochiku_yml
+    if kochiku_yml
+      case kochiku_yml['partitioner']
+      when 'maven'
+        Partitioner::Maven.new(build, kochiku_yml)
       else
-        [{'type' => 'spec', 'files' => ['no-manifest'], 'queue' => queue_for_build(build), 'retry_count' => 0}]
-      end
-    end
-  end
-
-  private
-
-  def max_build_time
-    if @kochiku_yml.is_a?(Array)
-      @kochiku_yml
-    else
-      @kochiku_yml.fetch('targets')
-    end.map do |subset|
-      file_to_times_hash = load_manifest(subset['time_manifest'])
-      if file_to_times_hash.is_a?(Hash)
-        file_to_times_hash.values
-      end
-    end.flatten.compact.max
-  end
-
-  def queue_for_build(build)
-    build.project.main? ? "ci" : "developer"
-  end
-
-  def build_partitions(build)
-    if @kochiku_yml['ruby']
-      @kochiku_yml['ruby'].flat_map do |ruby|
-        build_targets(build, ruby)
+        # Default behavior
+        Partitioner::Default.new(build, kochiku_yml)
       end
     else
-      build_targets(build)
-    end
-  end
-
-  def build_targets(build, ruby_version=nil)
-    options = {}
-    options['language'] = @kochiku_yml['language'] if @kochiku_yml['language']
-    options['ruby'] = ruby_version if ruby_version
-    options['log_file_globs'] = @kochiku_yml['log_file_globs'] if @kochiku_yml['log_file_globs']
-
-    @kochiku_yml['targets'].flat_map do |subset|
-      partitions_for(
-        build,
-        subset.merge('options' => options.merge(subset.fetch('options', {})))
-      )
-    end
-  end
-
-  def partitions_for(build, subset)
-    subset['options'] ||= {}
-    glob = subset.fetch('glob', '/dev/null')
-    type = subset.fetch('type', 'test')
-    workers = subset.fetch('workers', 1)
-    manifest = subset['manifest']
-    retry_count = subset['retry_count'] || 0
-    subset['options']['log_file_globs'] = subset['log_file_globs'] if subset['log_file_globs']
-
-    queue = queue_for_build(build)
-
-    queue_override = subset.fetch('queue_override', nil)
-    queue = queue_override if queue_override.present?
-
-    strategy = subset.fetch('balance', 'round_robin')
-    strategy = 'round_robin' unless Strategies.respond_to?(strategy) # override if specified strategy is invalid
-
-    files = Array(load_manifest(manifest)) | Dir[*glob]
-
-    file_to_times_hash = load_manifest(subset['time_manifest'])
-
-    balanced_partitions = if file_to_times_hash.is_a?(Hash)
-      @max_time ||= max_build_time
-      time_greedy_partitions_for(file_to_times_hash, files, workers)
-    else
-      []
-    end
-
-    files -= balanced_partitions.flatten
-
-    (Strategies.send(strategy, files, workers) + balanced_partitions).map do |part_files|
-      part = {'type' => type, 'files' => part_files.compact, 'queue' => queue,
-              'retry_count' => retry_count, 'options' => subset['options']}
-      part
-    end.select { |p| p['files'].present? }
-  end
-
-  # Balance tests by putting each test into the worker with the shortest expected execution time
-  # If a test that no longer exists is referenced in the file_to_times_hash, do not include it in
-  # the list of tests to be executed.  If there are new tests not included in the file_to_times_hash,
-  # assume they will run fast.
-  def time_greedy_partitions_for(file_to_times_hash, all_files, workers)
-    # exclude tests that are not present
-    file_to_times_hash.slice!(*all_files)
-    min_test_time = file_to_times_hash.values.flatten.min
-    setup_time = (min_test_time)/2
-    # Any new tests get added in here.
-    all_files.each  { |file| file_to_times_hash[file] ||= [min_test_time] }
-
-    files_by_worker = []
-    runtimes_by_worker = []
-
-    file_to_times_hash.to_a.sort_by { |a| a.last.max }.reverse_each do |file, times|
-      file_runtime = times.max
-      if runtimes_by_worker.length < workers
-        files_by_worker << [file]
-        runtimes_by_worker << file_runtime
-      else
-        fastest_worker_time, fastest_worker_index = runtimes_by_worker.each_with_index.min
-        files_by_worker[fastest_worker_index] << file
-        runtimes_by_worker[fastest_worker_index] += file_runtime - setup_time
-      end
-    end
-    files_by_worker
-  end
-
-  def load_manifest(file_name)
-    YAML.load_file(file_name) if file_name
-  end
-
-  module Strategies
-    class << self
-      def alphabetically(files, workers)
-        files.in_groups(workers)
-      end
-
-      def isolated(files, workers)
-        files.in_groups_of(1)
-      end
-
-      def round_robin(files, workers)
-        files.in_groups_of(workers).transpose
-      end
-
-      def shuffle(files, workers)
-        files.shuffle.in_groups(workers)
-      end
-
-      def size(files, workers)
-        files.sort_by { |path| File.size(path) }.reverse.in_groups_of(workers).transpose
-      end
-
-      def size_greedy_partitioning(files, workers)
-        files = files.sort_by { |path| 0 - File.size(path) }
-        numbers = (0...workers).to_a
-        results = numbers.map { [] }
-        sizes = numbers.map { 0 }
-        files.each do |file|
-          dest = numbers.sort_by { |n| sizes[n] }.first
-          sizes[dest] += File.size(file)
-          results[dest] << file
-        end
-        return results
-      end
-
-      def size_average_partitioning(files, workers)
-        threshold = files.sum { |file| File.size(file) } / workers
-        results = []
-        this_bucket = []
-        this_bucket_size = 0
-
-        files.each do |file|
-          if this_bucket_size > threshold && results.size < workers
-            results << this_bucket
-            this_bucket = []
-            this_bucket_size = this_bucket_size - threshold
-          end
-
-          this_bucket << file
-          this_bucket_size += File.size(file)
-        end
-
-        results << this_bucket
-        return results
-      end
+      # This should probably raise
+      Partitioner::Base.new(build, kochiku_yml)
     end
   end
 end

--- a/lib/partitioner/base.rb
+++ b/lib/partitioner/base.rb
@@ -1,0 +1,23 @@
+module Partitioner
+  class Base
+    def initialize(build, kochiku_yml)
+      @build = build
+      @kochiku_yml = kochiku_yml
+    end
+
+    def partitions
+      [
+        {
+          'type' => 'test',
+          'files' => ['no-manifest'],
+          'queue' => @build.project.main? ? 'ci' : 'developer',
+          'retry_count' => 0
+        }
+      ]
+    end
+
+    def emails_for_commits_causing_failures
+      {}
+    end
+  end
+end

--- a/lib/partitioner/default.rb
+++ b/lib/partitioner/default.rb
@@ -1,0 +1,183 @@
+
+module Partitioner
+
+  # This is the origional partitioner behavior, which is somewhat ruby targeted
+  class Default < Base
+    def partitions
+      GitRepo.inside_copy(@build.repository, @build.ref) do
+        # Handle old kochiku.yml
+        if @kochiku_yml.is_a?(Array)
+          @kochiku_yml.map { |subset| partitions_for(subset) }.flatten
+        else
+          build_partitions
+        end
+      end
+    end
+
+    private
+
+    def max_build_time
+      if @kochiku_yml.is_a?(Array)
+        @kochiku_yml
+      else
+        @kochiku_yml.fetch('targets')
+      end.map do |subset|
+        file_to_times_hash = load_manifest(subset['time_manifest'])
+        if file_to_times_hash.is_a?(Hash)
+          file_to_times_hash.values
+        end
+      end.flatten.compact.max
+    end
+
+    def build_partitions
+      if @kochiku_yml['ruby']
+        @kochiku_yml['ruby'].flat_map do |ruby|
+          build_targets(ruby)
+        end
+      else
+        build_targets
+      end
+    end
+
+    def build_targets(ruby_version=nil)
+      options = {}
+      options['language'] = @kochiku_yml['language'] if @kochiku_yml['language']
+      options['ruby'] = ruby_version if ruby_version
+
+      @kochiku_yml['targets'].flat_map do |subset|
+        partitions_for(
+          subset.merge('options' => options)
+        )
+      end
+    end
+
+    def partitions_for(subset)
+      glob = subset.fetch('glob', '/dev/null')
+      type = subset.fetch('type', 'test')
+      workers = subset.fetch('workers', 1)
+      manifest = subset['manifest']
+      retry_count = subset['retry_count'] || 0
+      log_files = subset['log_file_globs']
+
+      queue = @build.project.main? ? "ci" : "developer"
+      queue_override = subset.fetch('queue_override', nil)
+      queue = "#{queue}-#{queue_override}" if queue_override.present?
+
+      strategy = subset.fetch('balance', 'round_robin')
+      strategy = 'round_robin' unless Strategies.respond_to?(strategy) # override if specified strategy is invalid
+
+      files = Array(load_manifest(manifest)) | Dir[*glob]
+
+      file_to_times_hash = load_manifest(subset['time_manifest'])
+
+      balanced_partitions = if file_to_times_hash.is_a?(Hash)
+                              @max_time ||= max_build_time
+                              time_greedy_partitions_for(file_to_times_hash, files, workers)
+                            else
+                              []
+                            end
+
+      files -= balanced_partitions.flatten
+
+      (Strategies.send(strategy, files, workers) + balanced_partitions).map do |part_files|
+        part = {'type' => type, 'files' => part_files.compact, 'queue' => queue,
+                'retry_count' => retry_count, 'log_file_globs' => log_files}
+        if subset['options']
+          part['options'] = subset['options']
+        end
+        part
+      end.select { |p| p['files'].present? }
+    end
+
+    # Balance tests by putting each test into the worker with the shortest expected execution time
+    # If a test that no longer exists is referenced in the file_to_times_hash, do not include it in
+    # the list of tests to be executed.  If there are new tests not included in the file_to_times_hash,
+    # assume they will run fast.
+    def time_greedy_partitions_for(file_to_times_hash, all_files, workers)
+      # exclude tests that are not present
+      file_to_times_hash.slice!(*all_files)
+      min_test_time = file_to_times_hash.values.flatten.min
+      setup_time = (min_test_time)/2
+      # Any new tests get added in here.
+      all_files.each  { |file| file_to_times_hash[file] ||= [min_test_time] }
+
+      files_by_worker = []
+      runtimes_by_worker = []
+
+      file_to_times_hash.to_a.sort_by { |a| a.last.max }.reverse_each do |file, times|
+        file_runtime = times.max
+        if runtimes_by_worker.length < workers
+          files_by_worker << [file]
+          runtimes_by_worker << file_runtime
+        else
+          fastest_worker_time, fastest_worker_index = runtimes_by_worker.each_with_index.min
+          files_by_worker[fastest_worker_index] << file
+          runtimes_by_worker[fastest_worker_index] += file_runtime - setup_time
+        end
+      end
+      files_by_worker
+    end
+
+    def load_manifest(file_name)
+      YAML.load_file(file_name) if file_name
+    end
+
+    module Strategies
+      class << self
+        def alphabetically(files, workers)
+          files.in_groups(workers)
+        end
+
+        def isolated(files, workers)
+          files.in_groups_of(1)
+        end
+
+        def round_robin(files, workers)
+          files.in_groups_of(workers).transpose
+        end
+
+        def shuffle(files, workers)
+          files.shuffle.in_groups(workers)
+        end
+
+        def size(files, workers)
+          files.sort_by { |path| File.size(path) }.reverse.in_groups_of(workers).transpose
+        end
+
+        def size_greedy_partitioning(files, workers)
+          files = files.sort_by { |path| 0 - File.size(path) }
+          numbers = (0...workers).to_a
+          results = numbers.map { [] }
+          sizes = numbers.map { 0 }
+          files.each do |file|
+            dest = numbers.sort_by { |n| sizes[n] }.first
+            sizes[dest] += File.size(file)
+            results[dest] << file
+          end
+          return results
+        end
+
+        def size_average_partitioning(files, workers)
+          threshold = files.sum { |file| File.size(file) } / workers
+          results = []
+          this_bucket = []
+          this_bucket_size = 0
+
+          files.each do |file|
+            if this_bucket_size > threshold && results.size < workers
+              results << this_bucket
+              this_bucket = []
+              this_bucket_size = this_bucket_size - threshold
+            end
+
+            this_bucket << file
+            this_bucket_size += File.size(file)
+          end
+
+          results << this_bucket
+          return results
+        end
+      end
+    end
+  end
+end

--- a/lib/partitioner/maven.rb
+++ b/lib/partitioner/maven.rb
@@ -1,0 +1,200 @@
+require 'nokogiri'
+require 'set'
+
+module Partitioner
+
+  # This partitioner uses knowledge of Maven to shard large java repos
+  class Maven < Base
+    POM_XML = 'pom.xml'
+
+    def initialize(build, kochiku_yml)
+      @build = build
+      @settings = kochiku_yml.fetch('maven_settings', {}) if kochiku_yml
+      @settings ||= {}
+    end
+
+    def partitions
+      modules_to_build = Set.new
+
+      GitRepo.inside_copy(@build.repository, @build.ref) do
+        @settings.fetch('always_build', []).each do |maven_module|
+          modules_to_build.add(maven_module)
+        end
+
+        files_changed_method = @build.project.main? ? :files_changed_since_last_build : :files_changed_in_branch
+        GitBlame.send(files_changed_method, @build).each do |file_and_emails|
+          module_affected_by_file = file_to_module(file_and_emails[:file])
+
+          if module_affected_by_file.nil?
+            if file_and_emails[:file] != "pom.xml"
+              return all_partitions
+            end
+          else
+            modules_to_build.merge(depends_on_map[module_affected_by_file] || Set.new)
+          end
+        end
+
+        if @build.project.main? && @build.previous_build
+          modules_to_build.merge(@build.previous_build.build_parts.select(&:unsuccessful?).map(&:paths).flatten.uniq)
+        end
+      end
+
+      group_modules(modules_to_build)
+    end
+
+    def emails_for_commits_causing_failures
+      return {} unless @build.project.main?
+
+      failed_modules = @build.build_parts.failed_or_errored.inject(Set.new) do |failed_set, build_part|
+        build_part.paths.each { |path| failed_set.add(path) }
+        failed_set
+      end
+
+      email_and_files = Hash.new { |hash, key| hash[key] = [] }
+
+      GitRepo.inside_copy(@build.repository, @build.ref) do
+        GitBlame.files_changed_since_last_green(@build, :fetch_emails => true).each do |file_and_emails|
+          file = file_and_emails[:file]
+          emails = file_and_emails[:emails]
+          module_affected_by_file = file_to_module(file_and_emails[:file])
+
+          if module_affected_by_file.nil?
+            if file != "pom.xml"
+              emails.each { |email| email_and_files[email] << file }
+            end
+          elsif (set = depends_on_map[module_affected_by_file]) && !set.intersection(failed_modules).empty?
+            emails.each { |email| email_and_files[email] << file }
+          end
+        end
+      end
+
+      email_and_files.each_key { |email| email_and_files[email].sort!.uniq! }
+
+      email_and_files
+    end
+
+    # Everything below this line should be private
+
+    def maven_modules
+      return @maven_modules if @maven_modules
+      top_level_pom = Nokogiri::XML(File.read(POM_XML))
+      @maven_modules = top_level_pom.css('project>modules>module').map { |mvn_module| mvn_module.text }
+    end
+
+    def all_partitions
+      group_modules(maven_modules)
+    end
+
+    def pom_for(mvn_module)
+      Nokogiri::XML(File.read("#{mvn_module}/pom.xml"))
+    end
+
+    def group_modules(mvn_modules)
+      expanding_dirs = @settings.fetch('expand_directories', [])
+      mvn_modules.group_by do |m|
+        split_dirs = m.split("/")
+        if expanding_dirs.include? split_dirs.first
+          "#{split_dirs[0]}/#{split_dirs[1]}"
+        else
+          split_dirs.first
+        end
+      end.values.map { |modules| partition_info(modules) }
+    end
+
+    def partition_info(mvn_modules)
+      queue = @build.project.main? ? 'ci' : 'developer'
+      queue_override = @settings.fetch('queue_overrides', []).detect do |override|
+        override['queue'] if override['paths'].detect { |path| mvn_modules.include? path }
+      end
+      queue = "#{queue}-#{queue_override['queue']}" if queue_override.present?
+      {
+        'type' => 'maven',
+        'files' => mvn_modules.sort!,
+        'queue' => queue,
+        'retry_count' => 2
+      }
+    end
+
+    def depends_on_map
+      return @depends_on_map if @depends_on_map
+
+      module_depends_on_map = {}
+      module_dependency_map.each do |mvn_module, dep_set|
+        module_depends_on_map[mvn_module] ||= Set.new
+        module_depends_on_map[mvn_module].add(mvn_module)
+        dep_set.each do |dep|
+          module_depends_on_map[dep] ||= Set.new
+          module_depends_on_map[dep].add(dep)
+          module_depends_on_map[dep].add(mvn_module)
+        end
+      end
+
+      @depends_on_map = module_depends_on_map
+    end
+
+    def module_dependency_map
+      return @module_dependency_map if @module_dependency_map
+
+      group_artifact_map = {}
+
+      maven_modules.each do |mvn_module|
+        module_pom = pom_for(mvn_module)
+        group_id = module_pom.css('project>groupId').first
+        artifact_id = module_pom.css('project>artifactId').first
+        next unless group_id && artifact_id
+        group_id = group_id.text
+        artifact_id = artifact_id.text
+
+        group_artifact_map["#{group_id}:#{artifact_id}"] = "#{mvn_module}"
+      end
+
+      module_dependency_map = {}
+
+      maven_modules.each do |mvn_module|
+        module_pom = pom_for(mvn_module)
+        module_dependency_map[mvn_module] ||= Set.new
+
+        module_pom.css('project>dependencies>dependency').each do |dep|
+          group_id = dep.css('groupId').first.text
+          artifact_id = dep.css('artifactId').first.text
+
+          if mod = group_artifact_map["#{group_id}:#{artifact_id}"]
+            module_dependency_map[mvn_module].add(mod)
+          end
+        end
+      end
+
+      transitive_dependency_map = {}
+
+      module_dependency_map.keys.each do |mvn_module|
+        transitive_dependency_map[mvn_module] = transitive_dependencies(mvn_module, module_dependency_map)
+      end
+
+      @module_dependency_map = transitive_dependency_map
+    end
+
+    def transitive_dependencies(mvn_module, dependency_map)
+      result_set = Set.new
+      to_process = [mvn_module]
+
+      while dep_module = to_process.shift
+        deps = dependency_map[dep_module].to_a
+        to_process += (deps - result_set.to_a)
+        result_set << dep_module
+      end
+
+      result_set
+    end
+
+    def file_to_module(file_path)
+      return nil if @settings.fetch('ignore_directories', []).detect { |dir| file_path.start_with?(dir) }
+      dir_path = file_path
+      while (dir_path = File.dirname(dir_path)) != "."
+        if File.exists?("#{dir_path}/pom.xml")
+          return dir_path
+        end
+      end
+      nil
+    end
+  end
+end

--- a/spec/jobs/build_partitioning_job_spec.rb
+++ b/spec/jobs/build_partitioning_job_spec.rb
@@ -11,7 +11,7 @@ describe BuildPartitioningJob do
       before do
         allow(GitRepo).to receive(:inside_copy).and_yield
         allow(Build).to receive(:find).with(id).and_return(build)
-        allow(Partitioner).to receive(:new).and_return(partitioner)
+        allow(Partitioner).to receive(:for_build).with(build).and_return(partitioner)
         allow(partitioner).to receive(:partitions).and_return('PARTITIONS')
         allow(build).to receive(:partition).with('PARTITIONS')
       end
@@ -41,7 +41,7 @@ describe BuildPartitioningJob do
 
     context "when a non-retryable error occurs" do
       error_message = "A name error occurred"
-      before { allow(GitRepo).to receive(:inside_copy).and_raise(NameError.new(error_message)) }
+      before { allow(GitRepo).to receive(:load_kochiku_yml).and_raise(NameError.new(error_message)) }
 
       it "should re-raise the error and set the build state to errored" do
         expect { subject }.to raise_error(NameError)
@@ -53,7 +53,7 @@ describe BuildPartitioningJob do
     end
 
     context "when a retryable error occurs" do
-      before { allow(GitRepo).to receive(:inside_copy).and_raise(GitRepo::RefNotFoundError) }
+      before { allow(GitRepo).to receive(:load_kochiku_yml).and_raise(GitRepo::RefNotFoundError) }
 
       it "should re-raise the error and set the build state to waiting for sync" do
         expect { subject }.to raise_error(GitRepo::RefNotFoundError)

--- a/spec/jobs/build_state_update_job_spec.rb
+++ b/spec/jobs/build_state_update_job_spec.rb
@@ -102,7 +102,6 @@ describe BuildStateUpdateJob do
               expect { subject }.to_not change(project.builds, :count)
               expect(new_build.reload.state).to eq(:failed)
             end
-
           end
 
           context "no new sha" do

--- a/spec/lib/build_strategies/production_build_strategy_spec.rb
+++ b/spec/lib/build_strategies/production_build_strategy_spec.rb
@@ -83,6 +83,7 @@ describe BuildStrategy do
     before do
       repository.update_attribute(:on_success_script, "./this_is_a_triumph")
       allow(GitRepo).to receive(:inside_copy).and_yield
+      allow(GitRepo).to receive(:load_kochiku_yml).and_return(nil)
     end
 
     it "run success script only once" do

--- a/spec/lib/git_blame_spec.rb
+++ b/spec/lib/git_blame_spec.rb
@@ -120,6 +120,23 @@ describe GitBlame do
     end
   end
 
+  describe "#files_changed_since_last_build" do
+    let(:options) { {} }
+    subject { GitBlame.files_changed_since_last_build(build, options) }
+
+    before do
+      allow(GitBlame).to receive(:files_changed_since_last_build).and_call_original
+    end
+
+    it "should parse the git log and return change file paths" do
+      allow(GitRepo).to receive(:inside_repo).and_return("::!::User One:userone@example.com::!::\n\npath/one/file.java\npath/two/file.java")
+      git_file_changes = subject
+      expect(git_file_changes.size).to eq(2)
+      expect(git_file_changes).to include({:file => "path/one/file.java", :emails => []})
+      expect(git_file_changes).to include({:file => "path/two/file.java", :emails => []})
+    end
+  end
+
   describe "#files_changed_since_last_green" do
     let(:options) { {} }
     subject { GitBlame.files_changed_since_last_green(build, options) }

--- a/spec/lib/partitioner/default_spec.rb
+++ b/spec/lib/partitioner/default_spec.rb
@@ -1,0 +1,305 @@
+require 'spec_helper'
+require 'partitioner'
+
+describe Partitioner::Default do
+  let(:build) { FactoryGirl.create(:build) }
+  let(:partitioner) { Partitioner::Default.new(build, build.kochiku_yml) }
+
+  before do
+    allow(GitRepo).to receive(:load_kochiku_yml).and_return(kochiku_yml)
+    allow(GitRepo).to receive(:inside_copy).and_yield()
+  end
+
+  let(:kochiku_yml) {
+    [
+      {
+        'type' => 'rspec',
+        'glob' => 'spec/**/*_spec.rb',
+        'workers' => 3,
+        'balance' => rspec_balance,
+        'manifest' => rspec_manifest,
+        'time_manifest' => rspec_time_manifest,
+      },
+      {
+        'type' => 'cuke',
+        'glob' => 'features/**/*.feature',
+        'workers' => 3,
+        'balance' => cuke_balance,
+        'manifest' => cuke_manifest,
+        'time_manifest' => cuke_time_manifest,
+      }
+    ]
+  }
+
+  let(:rspec_balance) { 'alphabetically' }
+  let(:rspec_manifest) { nil }
+  let(:cuke_balance) { 'alphabetically' }
+  let(:cuke_manifest) { nil }
+  let(:rspec_time_manifest) { nil }
+  let(:cuke_time_manifest) { nil }
+
+  describe '#emails_for_commits_causing_failures' do
+    subject { partitioner.emails_for_commits_causing_failures }
+    it "should return a hash" do
+      expect(subject).to be_a(Hash)
+    end
+  end
+
+  describe '#partitions' do
+    subject { partitioner.partitions }
+
+    context "with a kochiku.yml that does not use Ruby" do
+      let(:kochiku_yml) do
+        {
+          "targets" => [
+            {
+              'type' => 'other',
+              'glob' => 'spec/**/*_spec.rb',
+              'workers' => 1,
+            }
+          ]
+        }
+      end
+
+      it "should not include a ruby version" do
+        partitions = subject
+        expect(partitions.size).to be(1)
+        expect(partitions.first["type"]).to eq("other")
+        expect(partitions.first["files"]).not_to be_empty
+        expect(partitions.first["options"]).not_to have_key("ruby")
+      end
+    end
+
+
+    context "with a ruby-based kochiku.yml" do
+      let(:queue_override) { nil }
+      let(:retry_count) { nil }
+      let(:kochiku_yml) do
+        {
+          "ruby" => ["ree-1.8.7-2011.12"],
+          "language" => "ruby",
+          "targets" => [
+            {
+              'type' => 'rspec',
+              'glob' => 'spec/**/*_spec.rb',
+              'workers' => 3,
+              'balance' => rspec_balance,
+              'manifest' => rspec_manifest,
+              'queue_override' => queue_override,
+              'retry_count' => retry_count,
+            }
+          ]
+        }
+      end
+
+      it "parses options from kochiku yml" do
+        partitions = subject
+        expect(partitions.first["options"]["language"]).to eq("ruby")
+        expect(partitions.first["options"]["ruby"]).to eq("ree-1.8.7-2011.12")
+        expect(partitions.first["type"]).to eq("rspec")
+        expect(partitions.first["files"]).not_to be_empty
+        expect(partitions.first["queue"]).to eq("developer")
+        expect(partitions.first["retry_count"]).to eq(0)
+      end
+
+      context "with a master build" do
+        let(:build) { FactoryGirl.create(:main_project_build) }
+
+        it "should use the ci queue" do
+          expect(build.project).to be_main
+          expect(subject.first["queue"]).to eq("ci")
+        end
+
+        context "with queue_override" do
+          let(:queue_override) { "override" }
+          it "should override the queue on the build part" do
+            expect(subject.first["queue"]).to eq("ci-override")
+          end
+        end
+      end
+
+      context "with a branch build" do
+        it "should use the developer queue" do
+          expect(build.project).to_not be_main
+          expect(subject.first["queue"]).to eq("developer")
+        end
+
+        context "with queue_override" do
+          let(:queue_override) { "override" }
+          it "should override the queue on the build part" do
+            expect(subject.first["queue"]).to eq("developer-override")
+          end
+        end
+
+        context "with retry_count" do
+          let(:retry_count) { 2 }
+          it "should set the retry count" do
+            expect(subject.first["retry_count"]).to eq(2)
+          end
+        end
+      end
+    end
+
+
+    context 'when the glob matches' do
+      before { allow(Dir).to receive(:[]).and_return(matches) }
+
+      context 'no files' do
+        let(:matches) { [] }
+        it { should == [] }
+      end
+
+      context 'one file' do
+        let(:matches) { %w(a) }
+        it { [{ 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil }].each { |partition| should include(partition) } }
+      end
+
+      context 'multiple files' do
+        let(:matches) { %w(a b c d) }
+        it {
+          [
+            { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+          ].each { |partition| should include(partition) }
+        }
+
+        context 'and balance is round_robin' do
+          let(:rspec_balance) { 'round_robin' }
+          it {
+            [
+              { 'type' => 'rspec', 'files' => %w(a d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            ].each { |partition| should include(partition) }
+          }
+
+          context 'and a manifest file is specified' do
+            before { allow(YAML).to receive(:load_file).with(rspec_manifest).and_return(%w(c b a)) }
+            let(:rspec_manifest) { 'manifest.yml' }
+            let(:matches) { %w(a b c d) }
+
+            it {
+              [
+                { 'type' => 'rspec', 'files' => %w(c d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+                { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+                { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              ].each { |partition| should include(partition) }
+            }
+          end
+
+          context 'and time manifest files are specified' do
+            before do allow(YAML).to receive(:load_file).with(rspec_time_manifest).and_return(
+              {
+                'a.spec' => [2],
+                'b.spec' => [5, 8],
+                'c.spec' => [9, 6],
+                'd.spec' => [5, 8],
+                'deleted.spec' => [10],
+              }
+            )
+            end
+
+            before do allow(YAML).to receive(:load_file).with(cuke_time_manifest).and_return(
+              {
+                'f.feature' => [2],
+                'g.feature' => [5, 8],
+                'h.feature' => [6, 9],
+                'i.feature' => [15, 16],
+              }
+            )
+            end
+
+            let(:rspec_time_manifest) { 'rspec_time_manifest.yml' }
+            let(:cuke_time_manifest) { 'cuke_time_manifest.yml' }
+            let(:spec_matches) { %w(a.spec b.spec c.spec d.spec e.spec) }
+            let(:feature_matches) { %w(f.feature g.feature h.feature i.feature) }
+
+            it 'should greedily partition files in the time_manifest, and round robin the remaining files' do
+              allow(Dir).to receive(:[]).with("spec/**/*_spec.rb").and_return(spec_matches)
+              allow(Dir).to receive(:[]).with("features/**/*.feature").and_return(feature_matches)
+              [
+                {"type"=>"rspec", "files"=>["c.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
+                {"type"=>"rspec", "files"=>["d.spec", "e.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
+                {"type"=>"rspec", "files"=>["b.spec", "a.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
+                {"type"=>"cuke", "files"=>["i.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
+                {"type"=>"cuke", "files"=>["h.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
+                {"type"=>"cuke", "files"=>["g.feature", "f.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil}
+              ].each { |partition| should include(partition) }
+            end
+          end
+        end
+
+        context 'and balance is size' do
+          let(:rspec_balance) { 'size' }
+
+          before do
+            allow(File).to receive(:size).with('a').and_return(1)
+            allow(File).to receive(:size).with('b').and_return(1000)
+            allow(File).to receive(:size).with('c').and_return(100)
+            allow(File).to receive(:size).with('d').and_return(10)
+          end
+
+          it {
+            [
+              { 'type' => 'rspec', 'files' => %w(b a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            ].each { |partition| should include(partition) }
+          }
+        end
+
+        context 'and balance is size_greedy_partitioning' do
+          let(:rspec_balance) { 'size_greedy_partitioning' }
+
+          before do
+            allow(File).to receive(:size).with('a').and_return(1)
+            allow(File).to receive(:size).with('b').and_return(1000)
+            allow(File).to receive(:size).with('c').and_return(100)
+            allow(File).to receive(:size).with('d').and_return(10)
+          end
+
+          it {
+            [
+              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(d a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            ].each { |partition| should include(partition) }
+          }
+        end
+
+        context 'and balance is size_average_partitioning' do
+          let(:rspec_balance) { 'size_average_partitioning' }
+
+          before do
+            allow(File).to receive(:size).with('a').and_return(1)
+            allow(File).to receive(:size).with('b').and_return(1000)
+            allow(File).to receive(:size).with('c').and_return(100)
+            allow(File).to receive(:size).with('d').and_return(10)
+          end
+
+          it {
+            [
+              { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            ].each { |partition| should include(partition) }
+          }
+        end
+
+        context 'and balance is isolated' do
+          let(:rspec_balance) { 'isolated' }
+
+          it {
+            [
+              { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
+            ].each { |partition| should include(partition) }
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/partitioner/maven_spec.rb
+++ b/spec/lib/partitioner/maven_spec.rb
@@ -1,0 +1,394 @@
+require 'spec_helper'
+require 'partitioner/maven'
+
+describe Partitioner::Maven do
+  let(:repository) { FactoryGirl.create(:repository) }
+  let(:project) { FactoryGirl.create(:project, :repository => repository, :name => repository.name) }
+  let(:build) { FactoryGirl.create(:build, :project => project, :branch => "master") }
+  let(:kochiku_yml) { nil }
+
+  subject { Partitioner::Maven.new(build, kochiku_yml) }
+
+  before do
+    allow(GitRepo).to receive(:inside_copy).and_yield
+  end
+
+  describe "#group_modules" do
+    it "should group modules based on the top level directory" do
+      allow(subject).to receive(:deployable_modules_map).and_return({})
+      modules = ["a", "b", "b/1", "b/2", "b/1/2", "c/1"]
+      partitions = subject.group_modules(modules)
+      expect(partitions.size).to eq(3)
+      expect(partitions).to include({"type" => "maven", "files" => ["a"], "queue" => "ci", "retry_count" => 2})
+      expect(partitions).to include({"type" => "maven", "files" => ["b", "b/1", "b/1/2", "b/2"], "queue" => "ci", "retry_count" => 2})
+      expect(partitions).to include({"type" => "maven", "files" => ["c/1"], "queue" => "ci", "retry_count" => 2})
+    end
+
+    context "with expand_directories" do
+      let(:kochiku_yml) {
+        {
+          'maven_settings' => {
+            'expand_directories' => ['b'],
+          }
+        }
+      }
+      it "should break down modules when included in expand_directories" do
+        allow(subject).to receive(:deployable_modules_map).and_return({})
+        modules = ["a", "b", "b/elephant", "b/elephant/elephant-protos", "b/mint",]
+        partitions = subject.group_modules(modules)
+        expect(partitions.size).to eq(4)
+        expect(partitions).to include({"type" => "maven", "files" => ["a"], "queue" => "ci", "retry_count" => 2})
+        expect(partitions).to include({"type" => "maven", "files" => ["b"], "queue" => "ci", "retry_count" => 2})
+        expect(partitions).to include({"type" => "maven", "files" => ["b/elephant", "b/elephant/elephant-protos"], "queue" => "ci", "retry_count" => 2})
+        expect(partitions).to include({"type" => "maven", "files" => ["b/mint"], "queue" => "ci", "retry_count" => 2})
+      end
+    end
+  end
+
+  describe "#partitions" do
+    context "on master as the main build for the project" do
+      before do
+        expect(build.project).to be_main
+      end
+
+      context "for a given set of file changes" do
+        before do
+          allow(GitBlame).to receive(:files_changed_since_last_build).with(build)
+            .and_return([{:file => "module-one/src/main/java/com/lobsters/foo.java", :emails => []},
+                         {:file => "module-two/src/main/java/com/lobsters/bar.java", :emails => []}])
+          allow(File).to receive(:exists?).and_return(false)
+          allow(File).to receive(:exists?).with("module-one/pom.xml").and_return(true)
+          allow(File).to receive(:exists?).with("module-two/pom.xml").and_return(true)
+
+          allow(subject).to receive(:maven_modules).and_return(["module-one", "module-two", "module-two/integration", "module-three", "module-four"])
+          allow(subject).to receive(:depends_on_map).and_return({
+            "module-one" => ["module-one", "module-three", "module-four"].to_set,
+            "module-two" => ["module-two", "module-two/integration", "module-three"].to_set,
+          })
+          allow(subject).to receive(:deployable_modules_map).and_return({"module-four" => {}})
+          expect(subject).to_not receive(:all_partitions)
+        end
+
+        it "should return the set of modules to build" do
+          partitions = subject.partitions
+          expect(partitions.size).to eq(4)
+          expect(partitions).to include({"type" => "maven", "files" => ["module-one"], "queue" => "ci", "retry_count" => 2})
+          expect(partitions).to include({"type" => "maven", "files" => ["module-two", "module-two/integration"], "queue" => "ci", "retry_count" => 2})
+          expect(partitions).to include({"type" => "maven", "files" => ["module-three"], "queue" => "ci", "retry_count" => 2})
+          expect(partitions).to include({"type" => "maven", "files" => ["module-four"], "queue" => "ci", "retry_count" => 2})
+        end
+
+        context "with always_build set" do
+          let(:kochiku_yml) {
+            {
+              'maven_settings' => {
+                'always_build' => ['module-b'],
+              }
+            }
+          }
+
+          it "should always include the always_build in the partitions" do
+            partitions = subject.partitions
+            expect(partitions.size).to eq(5)
+            expect(partitions).to include({"type" => "maven", "files" => ["module-b"],
+                                           "queue" => "ci", "retry_count" => 2})
+          end
+        end
+      end
+
+      context "with a previous build" do
+        let(:build2) { FactoryGirl.create(:build, :project => project, :branch => "master") }
+        subject { Partitioner::Maven.new(build2, kochiku_yml) }
+
+        it "should add all the non-successful parts from the previous build" do
+          build_part = FactoryGirl.create(:build_part, :build_instance => build, :paths => ["module-one"])
+          expect(build.build_parts.first).to be_unsuccessful
+
+          partitions = subject.partitions
+          expect(partitions.size).to eq(1)
+          expect(partitions).to include({"type" => "maven", "files" => build_part.paths,
+                                         "queue" => build_part.queue.to_s, "retry_count" => 2})
+        end
+
+        it "should not add all successful parts from the previous build" do
+          build_part = FactoryGirl.create(:build_part, :build_instance => build, :paths => ["module-one"])
+          FactoryGirl.create(:build_attempt, :build_part => build_part, :state => :passed)
+          expect(build.build_parts.first).to be_successful
+
+          partitions = subject.partitions
+          expect(partitions.size).to eq(0)
+        end
+      end
+
+      it "should build everything if one of the files does not map to a module" do
+        allow(GitBlame).to receive(:files_changed_since_last_build).with(build)
+          .and_return([{:file => "toplevel/foo.xml", :emails => []}])
+
+        allow(subject).to receive(:depends_on_map).and_return({
+          "module-one" => ["module-one", "module-three", "module-four"].to_set,
+          "module-two" => ["module-two", "module-three"].to_set
+        })
+
+        expect(subject).to receive(:all_partitions).and_return([{"type" => "maven", "files" => "ALL"}])
+
+        partitions = subject.partitions
+        expect(partitions).to eq([{"type" => "maven", "files" => "ALL"}])
+      end
+
+      it "should not fail if a file is referenced in a top level module that is not in the top level pom" do
+        allow(GitBlame).to receive(:files_changed_since_last_build).with(build)
+          .and_return([{:file => "new-module/src/main/java/com/lobsters/foo.java", :emails => []}])
+
+        allow(File).to receive(:exists?).and_return(false)
+        allow(File).to receive(:exists?).with("new-module/pom.xml").and_return(true)
+
+        allow(subject).to receive(:maven_modules).and_return(["module-one", "module-two"])
+        allow(subject).to receive(:depends_on_map).and_return({
+          "module-one" => ["module-one", "module-three", "module-four"].to_set,
+          "module-two" => ["module-two", "module-three"].to_set
+        })
+        allow(subject).to receive(:deployable_modules_map).and_return({})
+        expect(subject).to_not receive(:all_partitions)
+
+        partitions = subject.partitions
+        expect(partitions.size).to eq(0)
+      end
+    end
+
+    context "on a branch" do
+      let(:build) { FactoryGirl.create(:build, :branch => "branch-of-master") }
+
+      before do
+        expect(build.project).to_not be_main
+      end
+
+      context "with a previous build" do
+        let(:build2) { FactoryGirl.create(:build, :project => project, :branch => "master") }
+        subject { Partitioner::Maven.new(build2, kochiku_yml) }
+
+        it "should NOT add all the non-successful parts from the previous build" do
+          FactoryGirl.create(:build_part, :build_instance => build, :paths => ["module-one"])
+          expect(build.build_parts.first).to be_unsuccessful
+
+          partitions = subject.partitions
+          expect(partitions.size).to eq(0)
+        end
+      end
+    end
+  end
+
+  describe "#emails_for_commits_causing_failures" do
+    it "should return nothing if there are no failed parts" do
+      expect(build.build_parts.failed_or_errored).to be_empty
+      emails = subject.emails_for_commits_causing_failures
+      expect(emails).to be_empty
+    end
+
+    it "should return the emails for the modules that are failing" do
+      build_part = FactoryGirl.create(:build_part, :paths => ["module-four"], :build_instance => build)
+      FactoryGirl.create(:build_attempt, :state => :failed, :build_part => build_part)
+      expect(build.build_parts.failed_or_errored).to eq([build_part])
+
+      allow(GitRepo).to receive(:inside_copy).and_yield
+      allow(GitBlame).to receive(:files_changed_since_last_green).with(build, :fetch_emails => true)
+        .and_return([{:file => "module-one/src/main/java/com/lobsters/Foo.java", :emails => ["userone@example.com"]},
+                     {:file => "module-two/src/main/java/com/lobsters/Bar.java", :emails => ["usertwo@example.com"]},
+                     {:file => "module-four/src/main/java/com/lobsters/Baz.java", :emails => ["userfour@example.com"]},
+                     {:file => "module-four/src/main/java/com/lobsters/Bing.java", :emails => ["userfour@example.com"]}])
+      allow(File).to receive(:exists?).and_return(false)
+      allow(File).to receive(:exists?).with("module-one/pom.xml").and_return(true)
+      allow(File).to receive(:exists?).with("module-two/pom.xml").and_return(true)
+      allow(File).to receive(:exists?).with("module-four/pom.xml").and_return(true)
+
+      allow(subject).to receive(:depends_on_map).and_return({
+                                                   "module-one" => ["module-one", "module-three", "module-four"].to_set,
+                                                   "module-two" => ["module-two", "module-three"].to_set,
+                                                   "module-four" => ["module-four"].to_set
+                                               })
+      expect(subject).to_not receive(:all_partitions)
+
+      email_and_files = subject.emails_for_commits_causing_failures
+      expect(email_and_files.size).to eq(2)
+      expect(email_and_files["userone@example.com"]).to eq(["module-one/src/main/java/com/lobsters/Foo.java"])
+      expect(email_and_files["userfour@example.com"].size).to eq(2)
+      expect(email_and_files["userfour@example.com"]).to include("module-four/src/main/java/com/lobsters/Baz.java")
+      expect(email_and_files["userfour@example.com"]).to include("module-four/src/main/java/com/lobsters/Bing.java")
+    end
+  end
+
+  describe "#depends_on_map" do
+    it "should convert a dependency map to a depends on map" do
+      allow(subject).to receive(:module_dependency_map).and_return({
+                                                        "module-one" => ["a", "b", "c"].to_set,
+                                                        "module-two" => ["b", "c", "module-one"].to_set,
+                                                        "module-three" => Set.new
+                                                      })
+
+      depends_on_map = subject.depends_on_map
+
+      expect(depends_on_map["module-one"]).to eq(["module-one", "module-two"].to_set)
+      expect(depends_on_map["module-two"]).to eq(["module-two"].to_set)
+      expect(depends_on_map["module-three"]).to eq(["module-three"].to_set)
+      expect(depends_on_map["a"]).to eq(["a", "module-one"].to_set)
+      expect(depends_on_map["b"]).to eq(["b", "module-one", "module-two"].to_set)
+      expect(depends_on_map["c"]).to eq(["c", "module-one", "module-two"].to_set)
+    end
+  end
+
+  context "with actual files" do
+
+    let(:top_level_pom) { <<-POM
+<project>
+  <modules>
+    <module>module-one</module>
+    <module>module-two</module>
+    <module>module-three</module>
+  </modules>
+</project>
+    POM
+    }
+
+    let(:module_one_pom) { <<-POM
+<project>
+  <properties>
+    <deployableBranch>one-branch</deployableBranch>
+  </properties>
+
+  <groupId>com.lobsters</groupId>
+  <artifactId>module-core</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.lobsters</groupId>
+      <artifactId>module-extras</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+    POM
+    }
+
+    let(:module_two_pom) { <<-POM
+<project>
+  <properties>
+    <deployableBranch>two-branch</deployableBranch>
+  </properties>
+
+  <groupId>com.lobsters</groupId>
+  <artifactId>module-extras</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.lobsters</groupId>
+      <artifactId>module-three</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+    POM
+    }
+
+    let(:module_three_pom) { <<-POM
+<project>
+  <groupId>com.lobsters</groupId>
+  <artifactId>module-three</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+  </dependencies>
+</project>
+    POM
+    }
+
+    describe "#module_dependency_map" do
+      it "it should get the transitive dependencies from a pom" do
+        allow(File).to receive(:read).with(Partitioner::Maven::POM_XML).and_return(top_level_pom)
+        allow(File).to receive(:read).with("module-one/pom.xml").and_return(module_one_pom)
+        allow(File).to receive(:read).with("module-two/pom.xml").and_return(module_two_pom)
+        allow(File).to receive(:read).with("module-three/pom.xml").and_return(module_three_pom)
+
+        dependency_map = subject.module_dependency_map
+
+        expect(dependency_map["module-one"]).to eq(["module-one", "module-two", "module-three"].to_set)
+        expect(dependency_map["module-two"]).to eq(["module-two", "module-three"].to_set)
+        expect(dependency_map["module-three"]).to eq(["module-three"].to_set)
+      end
+    end
+  end
+
+  describe "#transitive_dependencies" do
+    it "should return the module in a set as a base case" do
+      expect(subject.transitive_dependencies("module-one", {"module-one" => Set.new})).to eq(["module-one"].to_set)
+    end
+
+    it "should work for the recursive case" do
+      dependency_map = {
+        "module-one" => ["a", "b", "c"].to_set,
+        "a" => ["d"].to_set,
+        "b" => ["d", "e"].to_set,
+        "c" => Set.new,
+        "d" => ["e"].to_set,
+        "e" => Set.new,
+        "f" => Set.new
+      }
+
+      transitive_map = subject.transitive_dependencies("module-one", dependency_map)
+      expect(transitive_map).to eq(["module-one", "a", "b", "c", "d", "e"].to_set)
+    end
+  end
+
+  describe "#file_to_module" do
+    before do
+      allow(File).to receive(:exists?).and_return(false)
+    end
+
+    it "should return the module for a src main path" do
+      allow(File).to receive(:exists?).with("oyster/pom.xml").and_return(true)
+      expect(subject.file_to_module("oyster/src/main/java/com/lobsters/oyster/OysterApp.java")).to eq("oyster")
+    end
+
+    it "should return the module in a subdirectory" do
+      allow(File).to receive(:exists?).with("gateways/cafis/pom.xml").and_return(true)
+      expect(subject.file_to_module("gateways/cafis/src/main/java/com/lobsters/gateways/cafis/data/DataField_9_6_1.java"))
+        .to eq("gateways/cafis")
+    end
+
+    it "should return the module for a src test path even if there is pom in the parent directory" do
+      allow(File).to receive(:exists?).with("integration/hibernate/pom.xml").and_return(true)
+      allow(File).to receive(:exists?).with("integration/hibernate/tests/pom.xml").and_return(true)
+      expect(subject.file_to_module("integration/hibernate/tests/src/test/java/com/lobsters/integration/hibernate/ConfigurationExtTest.java"))
+        .to eq("integration/hibernate/tests")
+    end
+
+    it "should return a module for a pom change" do
+      allow(File).to receive(:exists?).with("common/pom.xml").and_return(true)
+      expect(subject.file_to_module("common/pom.xml")).to eq("common")
+    end
+
+    it "should return nil for a toplevel change" do
+      expect(subject.file_to_module("pom.xml")).to be_nil
+      expect(subject.file_to_module("Gemfile.lock")).to be_nil
+      expect(subject.file_to_module("non_maven_dependencies/README")).to be_nil
+    end
+
+    context "with ignore_directories set" do
+      let(:kochiku_yml) {
+        {
+          'maven_settings' => {
+            'ignore_directories' => ['a'],
+          }
+        }
+      }
+
+      it "should return nil for changes in an ignored directory" do
+        allow(File).to receive(:exists?).with("a/base/pom.xml").and_return(true)
+        expect(subject.file_to_module("a/base/pom.xml")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/partitioner_spec.rb
+++ b/spec/lib/partitioner_spec.rb
@@ -3,348 +3,59 @@ require 'partitioner'
 
 describe Partitioner do
   let(:build) { FactoryGirl.create(:build) }
-  let(:partitioner) { Partitioner.new }
 
   before do
     allow(GitRepo).to receive(:load_kochiku_yml).and_return(kochiku_yml)
+    allow(GitRepo).to receive(:inside_repo).and_yield()
     allow(GitRepo).to receive(:inside_copy).and_yield()
   end
 
-  let(:kochiku_yml) {
-    [
-      {
-        'type' => 'rspec',
-        'glob' => 'spec/**/*_spec.rb',
-        'workers' => 3,
-        'balance' => rspec_balance,
-        'manifest' => rspec_manifest,
-        'time_manifest' => rspec_time_manifest,
-      },
-      {
-        'type' => 'cuke',
-        'glob' => 'features/**/*.feature',
-        'workers' => 3,
-        'balance' => cuke_balance,
-        'manifest' => cuke_manifest,
-        'time_manifest' => cuke_time_manifest,
-      }
-    ]
-  }
+  describe "#for_build" do
+    subject { Partitioner.for_build(build) }
 
-  let(:pom_xml_exists) { false }
-  let(:rspec_balance) { 'alphabetically' }
-  let(:rspec_manifest) { nil }
-  let(:cuke_balance) { 'alphabetically' }
-  let(:cuke_manifest) { nil }
-  let(:rspec_time_manifest) { nil }
-  let(:cuke_time_manifest) { nil }
-
-  context "with a kochiku.yml that does not use Ruby" do
-    let(:kochiku_yml) do
-      {
-        "targets" => [
-          {
-            'type' => 'other',
-            'glob' => 'spec/**/*_spec.rb',
-            'workers' => 1,
-          }
-        ]
-      }
-    end
-
-    it "should not include a ruby version" do
-      partitions = partitioner.partitions(build)
-      expect(partitions.size).to be(1)
-      expect(partitions.first["type"]).to eq("other")
-      expect(partitions.first["files"]).not_to be_empty
-      expect(partitions.first["options"]).not_to have_key("ruby")
-    end
-  end
-
-  context "with a kochiku.yml that specifies log files" do
-    let(:kochiku_yml) do
-      {
-        'log_file_globs' => ['glob1'],
-        "targets" => [
-          {
-            'type' => 'other',
-            'glob' => 'spec/**/*_spec.rb',
-            'workers' => 1,
-          },
-        ]
-      }
-    end
-
-    it "should include the log_file_globs" do
-      partitions = partitioner.partitions(build)
-      expect(partitions.first['options']['log_file_globs']).to eq(['glob1'])
-    end
-
-    context "with a kochiku.yml that specifies log files" do
-      let(:kochiku_yml) do
-        {
-          'log_file_globs' => ['glob1'],
-          "targets" => [
-            {
-              'type' => 'other',
-              'glob' => 'spec/**/*_spec.rb',
-              'workers' => 1,
-              'log_file_globs' => ['glob2'],
-            },
-          ]
-        }
-      end
-
-      it "should not include a ruby version" do
-        partitions = partitioner.partitions(build)
-        expect(partitions.first['options']['log_file_globs']).to eq(['glob2'])
-      end
-    end
-  end
-
-  context "with a ruby-based kochiku.yml" do
-    let(:queue_override) { nil }
-    let(:retry_count) { nil }
-    let(:kochiku_yml) do
-      {
-        "ruby" => ["ree-1.8.7-2011.12"],
-        "language" => "ruby",
-        "targets" => [
-          {
-            'type' => 'rspec',
-            'glob' => 'spec/**/*_spec.rb',
-            'workers' => 3,
-            'balance' => rspec_balance,
-            'manifest' => rspec_manifest,
-            'queue_override' => queue_override,
-            'retry_count' => retry_count,
-          }
-        ]
-      }
-    end
-
-    it "parses options from kochiku yml" do
-      partitions = partitioner.partitions(build)
-      expect(partitions.first["options"]["language"]).to eq("ruby")
-      expect(partitions.first["options"]["ruby"]).to eq("ree-1.8.7-2011.12")
-      expect(partitions.first["type"]).to eq("rspec")
-      expect(partitions.first["files"]).not_to be_empty
-      expect(partitions.first["queue"]).to eq("developer")
-      expect(partitions.first["retry_count"]).to eq(0)
-    end
-
-    context "with a master build" do
-      let(:build) { FactoryGirl.create(:main_project_build) }
-
-      it "should use the ci queue" do
-        expect(build.project).to be_main
-        partitions = partitioner.partitions(build)
-        expect(partitions.first["queue"]).to eq("ci")
-      end
-    end
-
-    context "with a branch build" do
-      it "should use the developer queue" do
-        expect(build.project).to_not be_main
-        partitions = partitioner.partitions(build)
-        expect(partitions.first["queue"]).to eq("developer")
-      end
-    end
-
-    context "with queue_override" do
-      let(:queue_override) { "override" }
-      it "should override the queue on the build part" do
-        partitions = partitioner.partitions(build)
-        expect(partitions.first["queue"]).to eq("override")
-      end
-    end
-
-    context "with retry_count" do
-      let(:retry_count) { 2 }
-      it "should set the retry count" do
-        partitions = partitioner.partitions(build)
-        expect(partitions.first["retry_count"]).to eq(2)
-      end
-    end
-  end
-
-  context "when there is no kochiku yml" do
-    let(:kochiku_yml) { nil }
-
-    it "should return a single partiion" do
-      partitions = partitioner.partitions(build)
-      expect(partitions.size).to eq(1)
-      expect(partitions.first["type"]).to eq("spec")
-      expect(partitions.first["files"]).not_to be_empty
-    end
-  end
-
-  describe '#partitions' do
-    subject { partitioner.partitions(build) }
-
-    context 'when there is not a kochiku.yml' do
+    context "when there is no kochiku.yml" do
       let(:kochiku_yml) { nil }
-      it { should == [{"type" => "spec", "files" => ['no-manifest'], 'queue' => 'developer', 'retry_count' => 0}] }
+
+      it "should return a single partiion" do
+        partitions = subject.partitions
+        expect(partitions.size).to eq(1)
+        expect(partitions.first["type"]).to eq("test")
+        expect(partitions.first["files"]).not_to be_empty
+      end
     end
 
-    context 'when there is a kochiku.yml' do
-
-      before { allow(Dir).to receive(:[]).and_return(matches) }
-
-      context 'when there are no files matching the glob' do
-        let(:matches) { [] }
-        it { should == [] }
-      end
-
-      context 'when there is one file matching the glob' do
-        let(:matches) { %w(a) }
-        it { [{ 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} }].each { |partition| should include(partition) } }
-      end
-
-      context 'when there are many files matching the glob' do
-        let(:matches) { %w(a b c d) }
-        it {
-          [
-            { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-          ].each { |partition| should include(partition) }
-        }
-
-        context 'and balance is round_robin' do
-          let(:rspec_balance) { 'round_robin' }
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            ].each { |partition| should include(partition) }
-          }
-
-          context 'and a manifest file is specified' do
-            before { allow(YAML).to receive(:load_file).with(rspec_manifest).and_return(%w(c b a)) }
-            let(:rspec_manifest) { 'manifest.yml' }
-            let(:matches) { %w(a b c d) }
-
-            it {
-              [
-                { 'type' => 'rspec', 'files' => %w(c d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-                { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-                { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              ].each { |partition| should include(partition) }
-            }
-          end
-
-          context 'and time manifest files are specified' do
-            before do allow(YAML).to receive(:load_file).with(rspec_time_manifest).and_return(
-                {
-                  'a.spec' => [2],
-                  'b.spec' => [5, 8],
-                  'c.spec' => [9, 6],
-                  'd.spec' => [5, 8],
-                  'deleted.spec' => [10],
-                }
-              )
-            end
-
-            before do allow(YAML).to receive(:load_file).with(cuke_time_manifest).and_return(
+    context "when there is a kochiku.yml" do
+      context "when no partitioner is specified" do
+        let(:kochiku_yml) do
+          {
+            "ruby" => ["ree-1.8.7-2011.12"],
+            "language" => "ruby",
+            "targets" => [
               {
-                'f.feature' => [2],
-                'g.feature' => [5, 8],
-                'h.feature' => [6, 9],
-                'i.feature' => [15, 16],
+                'type' => 'rspec',
+                'glob' => 'spec/**/*_spec.rb',
+                'workers' => 3,
               }
-            )
-            end
-
-            let(:rspec_time_manifest) { 'rspec_time_manifest.yml' }
-            let(:cuke_time_manifest) { 'cuke_time_manifest.yml' }
-            let(:spec_matches) { %w(a.spec b.spec c.spec d.spec e.spec) }
-            let(:feature_matches) { %w(f.feature g.feature h.feature i.feature) }
-
-            it 'should greedily partition files in the time_manifest, and round robin the remaining files' do
-              allow(Dir).to receive(:[]).with("spec/**/*_spec.rb").and_return(spec_matches)
-              allow(Dir).to receive(:[]).with("features/**/*.feature").and_return(feature_matches)
-              [
-                  {"type"=>"rspec", "files"=>["c.spec"], "queue"=>"developer", "retry_count"=>0, 'options' => {}},
-                  {"type"=>"rspec", "files"=>["d.spec", "e.spec"], "queue"=>"developer", "retry_count"=>0, 'options' => {}},
-                  {"type"=>"rspec", "files"=>["b.spec", "a.spec"], "queue"=>"developer", "retry_count"=>0, 'options' => {}},
-                  {"type"=>"cuke", "files"=>["i.feature"], "queue"=>"developer", "retry_count"=>0, 'options' => {}},
-                  {"type"=>"cuke", "files"=>["h.feature"], "queue"=>"developer", "retry_count"=>0, 'options' => {}},
-                  {"type"=>"cuke", "files"=>["g.feature", "f.feature"], "queue"=>"developer", "retry_count"=>0, 'options' => {}}
-              ].each { |partition| should include(partition) }
-            end
-          end
-        end
-
-        context 'and balance is size' do
-          let(:rspec_balance) { 'size' }
-
-          before do
-            allow(File).to receive(:size).with('a').and_return(1)
-            allow(File).to receive(:size).with('b').and_return(1000)
-            allow(File).to receive(:size).with('c').and_return(100)
-            allow(File).to receive(:size).with('d').and_return(10)
-          end
-
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(b a), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            ].each { |partition| should include(partition) }
+            ]
           }
         end
 
-        context 'and balance is size_greedy_partitioning' do
-          let(:rspec_balance) { 'size_greedy_partitioning' }
-
-          before do
-            allow(File).to receive(:size).with('a').and_return(1)
-            allow(File).to receive(:size).with('b').and_return(1000)
-            allow(File).to receive(:size).with('c').and_return(100)
-            allow(File).to receive(:size).with('d').and_return(10)
-          end
-
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(d a), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            ].each { |partition| should include(partition) }
-          }
+        it "parses options from kochiku yml" do
+          partitions = subject.partitions
+          expect(partitions.first["options"]["language"]).to eq("ruby")
+          expect(partitions.first["options"]["ruby"]).to eq("ree-1.8.7-2011.12")
+          expect(partitions.first["type"]).to eq("rspec")
+          expect(partitions.first["files"]).not_to be_empty
+          expect(partitions.first["queue"]).to eq("developer")
+          expect(partitions.first["retry_count"]).to eq(0)
         end
+      end
 
-        context 'and balance is size_average_partitioning' do
-          let(:rspec_balance) { 'size_average_partitioning' }
+      context "when using the maven partitioner" do
+        let(:kochiku_yml) { {'partitioner' => 'maven'} }
 
-          before do
-            allow(File).to receive(:size).with('a').and_return(1)
-            allow(File).to receive(:size).with('b').and_return(1000)
-            allow(File).to receive(:size).with('c').and_return(100)
-            allow(File).to receive(:size).with('d').and_return(10)
-          end
-
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            ].each { |partition| should include(partition) }
-          }
-        end
-
-        context 'and balance is isolated' do
-          let(:rspec_balance) { 'isolated' }
-
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'options' => {} },
-            ].each { |partition| should include(partition) }
-          }
+        it "should call the maven partitioner" do
+          expect(subject).to be_a(Partitioner::Maven)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
     allow(GitBlame).to receive(:git_names_and_emails_in_branch).and_return("")
     allow(GitBlame).to receive(:changes_since_last_green).and_return([])
     allow(GitBlame).to receive(:changes_in_branch).and_return([])
+    allow(GitBlame).to receive(:files_changed_since_last_build).and_return([])
     allow(GitBlame).to receive(:files_changed_since_last_green).and_return([])
     allow(GitBlame).to receive(:files_changed_in_branch).and_return([])
 


### PR DESCRIPTION
The Maven Partitioner was built as a Square-specific extension to build a large Java repo, but after some refactoring to make way for extending kochiku with additional partitioners, it makes sense to bring the maven partitioner into the open source version.

Additional documentation on the wiki: https://github.com/square/kochiku/wiki/Maven-Partitioner
