### PR TITLE
`log_file_globs` behvaior back into the open

### DIFF
--- a/lib/partitioner/maven.rb
+++ b/lib/partitioner/maven.rb
@@ -9,7 +9,11 @@ module Partitioner
 
     def initialize(build, kochiku_yml)
       @build = build
-      @settings = kochiku_yml.fetch('maven_settings', {}) if kochiku_yml
+      @options = {}
+      if kochiku_yml
+        @settings = kochiku_yml['maven_settings'] if kochiku_yml['maven_settings']
+        @options['log_file_globs'] = Array(kochiku_yml['log_file_globs']) if kochiku_yml['log_file_globs']
+      end
       @settings ||= {}
     end
 
@@ -39,7 +43,9 @@ module Partitioner
         end
       end
 
-      group_modules(modules_to_build)
+      group_modules(modules_to_build).map do |group|
+        group.merge('options' => @options)
+      end
     end
 
     def emails_for_commits_causing_failures

--- a/spec/lib/partitioner/default_spec.rb
+++ b/spec/lib/partitioner/default_spec.rb
@@ -100,6 +100,7 @@ describe Partitioner::Default do
         expect(partitions.first["files"]).not_to be_empty
         expect(partitions.first["queue"]).to eq("developer")
         expect(partitions.first["retry_count"]).to eq(0)
+        expect(partitions.first['options']).not_to include('log_file_globs')
       end
 
       context "with a master build" do
@@ -140,74 +141,109 @@ describe Partitioner::Default do
       end
     end
 
+    context 'with log_file_globs' do
+      let(:kochiku_yml) do
+        {
+          'log_file_globs' => log_files,
+          'targets' => [
+            {
+              'type' => 'other',
+              'glob' => 'spec/**/*_spec.rb',
+              'workers' => 1,
+            }
+          ]
+        }
+      end
+
+      context 'that uses a single string' do
+        let(:log_files) { 'mylog.log' }
+
+        it 'puts an array into the options' do
+          expect(subject.first['options']['log_file_globs']).to eq(['mylog.log'])
+        end
+      end
+
+      context 'that uses an array' do
+        let(:log_files) { ['mylog.log', 'another.log'] }
+
+        it 'puts the array into the options' do
+          expect(subject.first['options']['log_file_globs']).to eq(['mylog.log', 'another.log'])
+        end
+      end
+    end
 
     context 'when the glob matches' do
       before { allow(Dir).to receive(:[]).and_return(matches) }
 
       context 'no files' do
         let(:matches) { [] }
-        it { should == [] }
+        it 'does nothing' do
+          expect(subject).to eq([])
+        end
       end
 
       context 'one file' do
         let(:matches) { %w(a) }
-        it { [{ 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil }].each { |partition| should include(partition) } }
+        it 'makes one partition' do
+          expect(subject).to include(a_hash_including({ 'files' => %w(a) }))
+        end
       end
 
       context 'multiple files' do
         let(:matches) { %w(a b c d) }
-        it {
-          [
-            { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-          ].each { |partition| should include(partition) }
-        }
+
+        # :rspec_balance set to alphabetically above
+        it 'using alphabetically' do
+          partitions = subject
+          expect(partitions).to include(a_hash_including({ 'files' => %w(a b) }))
+          expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+          expect(partitions).to include(a_hash_including({ 'files' => %w(d) }))
+        end
 
         context 'and balance is round_robin' do
           let(:rspec_balance) { 'round_robin' }
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            ].each { |partition| should include(partition) }
-          }
+
+          it 'uses round_robin' do
+            partitions = subject
+            expect(partitions).to include(a_hash_including({ 'files' => %w(a d) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(b) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+          end
 
           context 'and a manifest file is specified' do
             before { allow(YAML).to receive(:load_file).with(rspec_manifest).and_return(%w(c b a)) }
             let(:rspec_manifest) { 'manifest.yml' }
             let(:matches) { %w(a b c d) }
 
-            it {
-              [
-                { 'type' => 'rspec', 'files' => %w(c d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-                { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-                { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              ].each { |partition| should include(partition) }
-            }
+            it 'uses the manifest' do
+              partitions = subject
+              expect(partitions).to include(a_hash_including({ 'files' => %w(c d) }))
+              expect(partitions).to include(a_hash_including({ 'files' => %w(a) }))
+              expect(partitions).to include(a_hash_including({ 'files' => %w(b) }))
+            end
           end
 
           context 'and time manifest files are specified' do
-            before do allow(YAML).to receive(:load_file).with(rspec_time_manifest).and_return(
-              {
-                'a.spec' => [2],
-                'b.spec' => [5, 8],
-                'c.spec' => [9, 6],
-                'd.spec' => [5, 8],
-                'deleted.spec' => [10],
-              }
-            )
-            end
-
-            before do allow(YAML).to receive(:load_file).with(cuke_time_manifest).and_return(
-              {
-                'f.feature' => [2],
-                'g.feature' => [5, 8],
-                'h.feature' => [6, 9],
-                'i.feature' => [15, 16],
-              }
-            )
+            before do
+              allow(YAML).to receive(:load_file).with(rspec_time_manifest).and_return(
+                {
+                  'a.spec' => [2],
+                  'b.spec' => [5, 8],
+                  'c.spec' => [9, 6],
+                  'd.spec' => [5, 8],
+                  'deleted.spec' => [10],
+                }
+              )
+              allow(YAML).to receive(:load_file).with(cuke_time_manifest).and_return(
+                {
+                  'f.feature' => [2],
+                  'g.feature' => [5, 8],
+                  'h.feature' => [6, 9],
+                  'i.feature' => [15, 16],
+                }
+              )
+              allow(Dir).to receive(:[]).with("spec/**/*_spec.rb").and_return(spec_matches)
+              allow(Dir).to receive(:[]).with("features/**/*.feature").and_return(feature_matches)
             end
 
             let(:rspec_time_manifest) { 'rspec_time_manifest.yml' }
@@ -216,16 +252,13 @@ describe Partitioner::Default do
             let(:feature_matches) { %w(f.feature g.feature h.feature i.feature) }
 
             it 'should greedily partition files in the time_manifest, and round robin the remaining files' do
-              allow(Dir).to receive(:[]).with("spec/**/*_spec.rb").and_return(spec_matches)
-              allow(Dir).to receive(:[]).with("features/**/*.feature").and_return(feature_matches)
-              [
-                {"type"=>"rspec", "files"=>["c.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
-                {"type"=>"rspec", "files"=>["d.spec", "e.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
-                {"type"=>"rspec", "files"=>["b.spec", "a.spec"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
-                {"type"=>"cuke", "files"=>["i.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
-                {"type"=>"cuke", "files"=>["h.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil},
-                {"type"=>"cuke", "files"=>["g.feature", "f.feature"], "queue"=>"developer", "retry_count"=>0, "log_file_globs"=>nil}
-              ].each { |partition| should include(partition) }
+              partitions = subject
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['c.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['d.spec', 'e.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['b.spec', 'a.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['i.feature'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['h.feature'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['g.feature', 'f.feature']}))
             end
           end
         end
@@ -240,13 +273,12 @@ describe Partitioner::Default do
             allow(File).to receive(:size).with('d').and_return(10)
           end
 
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(b a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            ].each { |partition| should include(partition) }
-          }
+          it 'uses size' do
+            partitions = subject
+            expect(partitions).to include(a_hash_including({ 'files' => %w(b a) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(d) }))
+          end
         end
 
         context 'and balance is size_greedy_partitioning' do
@@ -259,13 +291,12 @@ describe Partitioner::Default do
             allow(File).to receive(:size).with('d').and_return(10)
           end
 
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(d a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            ].each { |partition| should include(partition) }
-          }
+          it 'uses greedy_size' do
+            partitions = subject
+            expect(partitions).to include(a_hash_including({ 'files' => %w(b) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(d a) }))
+          end
         end
 
         context 'and balance is size_average_partitioning' do
@@ -278,26 +309,24 @@ describe Partitioner::Default do
             allow(File).to receive(:size).with('d').and_return(10)
           end
 
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            ].each { |partition| should include(partition) }
-          }
+          it 'uses size_average' do
+            partitions = subject
+            expect(partitions).to include(a_hash_including({ 'files' => %w(a b) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(d) }))
+          end
         end
 
         context 'and balance is isolated' do
           let(:rspec_balance) { 'isolated' }
 
-          it {
-            [
-              { 'type' => 'rspec', 'files' => %w(a), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(b), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(c), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-              { 'type' => 'rspec', 'files' => %w(d), 'queue' => 'developer', 'retry_count' => 0, 'log_file_globs' => nil },
-            ].each { |partition| should include(partition) }
-          }
+          it 'isolates files' do
+            partitions = subject
+            expect(partitions).to include(a_hash_including({ 'files' => %w(a) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(b) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(c) }))
+            expect(partitions).to include(a_hash_including({ 'files' => %w(d) }))
+          end
         end
       end
     end


### PR DESCRIPTION
The `log_file_globs` setting didn't have any specs and was broken in the refactor. This fixes that setting, adds specs for it, and changes the existing partitioner specs to expect on the important parts of the partitions instead of matching.
