### PR TITLE
Now enforcing timeouts in the server

### DIFF
--- a/app/jobs/enforce_timeouts_job.rb
+++ b/app/jobs/enforce_timeouts_job.rb
@@ -1,0 +1,21 @@
+class EnforceTimeoutsJob
+  def self.perform
+    BuildAttempt.where(:state => 'running').each do |attempt|
+      lenient_timeout = attempt.build_instance.project.repository.timeout + 15
+      if attempt.elapsed_time > lenient_timeout.minutes
+        # Error artifact creation taken from kochiku-worker
+        message = StringIO.new
+        message.puts("This BuildAttempt has not been updated by its worker,\n" +
+                     "but the build taken longer than the project's timeout.")
+        message.rewind
+        def message.path
+          'error.txt'
+        end
+
+        BuildArtifact.create(:build_attempt_id => attempt.id, :log_file => message)
+        attempt.finish!(:errored)
+        Rails.logger.error "Errored BuildAttempt:#{ attempt.id } due to timeout"
+      end
+    end
+  end
+end

--- a/app/jobs/poll_repositories_job.rb
+++ b/app/jobs/poll_repositories_job.rb
@@ -8,7 +8,7 @@ class PollRepositoriesJob
       head = repo.sha_for_branch(branch)
       unless repo.build_for_commit(head)
         proj.builds.create!(ref: head, state: :partitioning, branch: branch)
-        Resque.logger.info "Build created for #{repo.name} at #{head}"
+        Rails.logger.info "Build created for #{repo.name} at #{head}"
       end
     end
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -8,7 +8,7 @@ class Repository < ActiveRecord::Base
   validates_presence_of :host, :name, :url
   validates_uniqueness_of :name
   validates_numericality_of :timeout, :only_integer => true
-  validates_inclusion_of :timeout, in: 0..1440, message: "the maximum timeout allowed is 1440 seconds"
+  validates_inclusion_of :timeout, :in => 0..1440, :message => 'The maximum timeout allowed is 1440 minutes'
 
   validates_uniqueness_of :url, :allow_blank => true
   validate :url_against_remote_servers

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -7,6 +7,15 @@ poll_repositories_for_changes:
   args:
   description: "Fetches any missed changes from added repositories"
 
+enforce_timeouts_on_attempts:
+  every:
+    - "10m"
+    - :first_in: "30m"
+  class: "EnforceTimeoutsJob"
+  queue: low
+  args:
+  description: "Errors any attempts where the workers should have timed out"
+
 # These autoscale jobs are turned off by default. Uncomment and configure
 # worker_thresholds in application.yml if you would like to use them.
 #

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -48,7 +48,7 @@ describe RepositoriesController do
         post :create, @params
         expect(response).to be_success
         expect(assigns[:repository].errors.full_messages.join(',')).
-          to include("the maximum timeout allowed is 1440 seconds")
+          to include("The maximum timeout allowed is 1440 minutes")
         expect(response).to render_template('new')
       end
     end

--- a/spec/jobs/enforce_timeouts_job_spec.rb
+++ b/spec/jobs/enforce_timeouts_job_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe EnforceTimeoutsJob do
+  let(:repository) { FactoryGirl.create(:repository, :url => 'git@github.com:square/test-repo.git', :timeout => 10) }
+  let(:project) { FactoryGirl.create(:big_rails_project, :repository => repository, :name => name) }
+  let(:build) { FactoryGirl.create(:build, :state => :runnable, :project => project) }
+  let(:build_part) { FactoryGirl.create(:build_part, :build_instance => build, :kind => :cucumber, :paths => ['baz'], :queue => :ci) }
+  let(:name) { repository.name + '_pull_requests' }
+
+  subject { EnforceTimeoutsJob.perform }
+
+  it 'mark timed-out builds as errored' do
+    attempt1 = BuildAttempt.create(:build_part_id => build_part.id, :started_at => 30.minutes.ago,
+                                   :state => :running, :builder => 'test-worker')
+    attempt2 = BuildAttempt.create(:build_part_id => build_part.id, :started_at => 10.minutes.ago,
+                                   :state => :running, :builder => 'test-worker')
+    subject
+    expect(attempt1.reload.state).to be(:errored)
+    expect(attempt2.reload.state).to be(:running)
+  end
+end


### PR DESCRIPTION
This will prevent builds that get lost being marked as running for long periods at a time.
