### PR TITLE
Remove ability to set repository name from edit form

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -100,7 +100,7 @@ class RepositoriesController < ApplicationController
 
   def repository_params
     params.require(:repository).
-      permit(:url, :name, :timeout, :build_pull_requests,
+      permit(:url, :timeout, :build_pull_requests,
              :run_ci, :on_green_update, :send_build_success_email,
              :send_build_failure_email, :allows_kochiku_merges,
              :email_on_first_failure)

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -3,9 +3,6 @@
   %div
     %label{:for => "url"} Repository URL:
     = f.text_field :url, {:placeholder => '', :autocapitalize => 'off', :autocorrect => 'off', :spellcheck => 'false'}
-  %div
-    %label{:for => "name"} Repository Name:
-    = f.text_field :name, {:placeholder => '(default is based off url)', :autocapitalize => 'off', :autocorrect => 'off', :spellcheck => 'false'}
   - if @repository.test_command.present?
     %div{ title: 'Test command should now be specified in the kochiku.yml' }
       %label{:for => "test_command"} Test Command: (Deprecated)

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -15,6 +15,15 @@ describe RepositoriesController do
       }.to change(Repository, :count).by(1)
       repository = Repository.where(url: "git@git.example.com:square/kochiku.git").first
       expect(repository).to be_present
+      expect(repository.name).to eq('kochiku')
+    end
+
+    it "sets host, namespace, and name based on the repo url" do
+      post :create, @params
+      repository = Repository.where(url: "git@git.example.com:square/kochiku.git").first
+      expect(repository.host).to eq('git.example.com')
+      expect(repository.namespace).to eq('square')
+      expect(repository.name).to eq('kochiku')
     end
 
     it "creates a ci and pull_requests project" do
@@ -25,19 +34,6 @@ describe RepositoriesController do
       repository = Repository.where(url: "git@git.example.com:square/kochiku.git").first
       expect(repository.projects.size).to eq(2)
       expect(repository.projects.map(&:name).sort).to eq(["kochiku", "kochiku-pull_requests"])
-    end
-
-    context "with repository name" do
-      it "creates a project with the specified name" do
-        @params[:repository][:name] = 'a-project-name'
-        expect{
-          post :create, @params
-          expect(response).to be_redirect
-        }.to change(Project, :count).by(2)
-        repository = Repository.where(url: "git@git.example.com:square/kochiku.git").first
-        expect(repository.projects.size).to eq(2)
-        expect(repository.projects.map(&:name).sort).to eq(["a-project-name", "a-project-name-pull_requests"])
-      end
     end
 
     context "with validation errors" do
@@ -120,7 +116,6 @@ describe RepositoriesController do
     # string attributes
     [
       :on_green_update,
-      :name
     ].each do |attribute|
       it "should successfully update the #{attribute} attribute" do
         new_value = "Keytar Intelligentsia artisan typewriter 3 wolf moon"


### PR DESCRIPTION
After the changes in https://github.com/square/kochiku/pull/75, the repository name needs to based on the git URL otherwise repository lookups will not work.
