### PR TITLE
Provide kochiku_env to resque build_attempt jobs

### DIFF
--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -37,6 +37,7 @@ class BuildPart < ActiveRecord::Base
         "remote_name" => "origin",
         "timeout" => project.repository.timeout.minutes,
         "options" => options,
+        "kochiku_env" => Rails.env,
     }
   end
 

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -43,6 +43,7 @@ describe BuildPart do
         expect(arg_hash["test_command"]).not_to be_blank
         expect(arg_hash["repo_url"]).not_to be_blank
         expect(arg_hash["options"]).to eq({"ruby" => "ree"})
+        expect(arg_hash["kochiku_env"]).to eq("test")
       end
       build_part.create_and_enqueue_new_build_attempt!
     end


### PR DESCRIPTION
Needed for kochiku-worker PR https://github.com/square/kochiku-worker/pull/37

Together, the PR's will provide the environment variable $KOCHIKU_ENV to build attempt jobs, containing the current RAILS_ENV on kochiku.