### PR TITLE
Fix RemoteServer matchers to guard against extra forward slashes

### DIFF
--- a/lib/remote_server/github.rb
+++ b/lib/remote_server/github.rb
@@ -8,9 +8,9 @@ module RemoteServer
   # All integration with Github must go via this class.
   class Github
     URL_PARSERS = [
-      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[-.\w]+?)(\.git)?\z},       # git@
-      %r{\Agit://(?<host>.*)/(?<username>.*)/(?<name>[-.\w]+)\.git\z},         # git://  (GHE only)
-      %r{\Ahttps?://(?<host>.*)/(?<username>.*)/(?<name>[-.\w]+?)(\.git)?\z},  # https://
+      %r{\Agit@(?<host>[^:]*):(?<username>[^\/]*)/(?<name>[-.\w]+?)(\.git)?\z},        # git@
+      %r{\Agit://(?<host>[^\/]*)/(?<username>[^\/]*)/(?<name>[-.\w]+)\.git\z},         # git://  (GHE only)
+      %r{\Ahttps?://(?<host>[^\/]*)/(?<username>[^\/]*)/(?<name>[-.\w]+?)(\.git)?\z},  # https://
     ]
 
     def initialize(url, server)

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -9,9 +9,9 @@ module RemoteServer
     attr_reader :stash_request
 
     URL_PARSERS = [
-      %r{\Agit@(?<host>.*):(?<username>.*)/(?<name>[-.\w]+)\.git\z},
-      %r{\Assh://git@(?<host>.*?)(?<port>:\d+)?/(?<username>.*)/(?<name>[-.\w]+)\.git\z},
-      %r{\Ahttps://(?<host>[^@]+)/scm/(?<username>.+)/(?<name>[-.\w]+)\.git\z},
+      %r{\Agit@(?<host>[^:]*):(?<username>[^\/]*)/(?<name>[-.\w]+)\.git\z},
+      %r{\Assh://git@(?<host>[^\/]*?)(?<port>:\d+)?/(?<username>[^\/]*)/(?<name>[-.\w]+)\.git\z},
+      %r{\Ahttps://(?<host>[^@\/]+)/scm/(?<username>[^\/]*)/(?<name>[-.\w]+)\.git\z},
     ]
 
     def initialize(url, server)

--- a/spec/lib/remote_server/github_spec.rb
+++ b/spec/lib/remote_server/github_spec.rb
@@ -79,7 +79,7 @@ describe RemoteServer::Github do
     end
 
     it 'should not allow characters disallowed by Github in repository names' do
-      %w(! @ # $ % ^ & * ( ) = + \ | ` ~ [ ] { } : ; ' " ?).each do |symbol|
+      %w(! @ # $ % ^ & * ( ) = + \ | ` ~ [ ] { } : ; ' " ? /).each do |symbol|
         expect {
           make_server("git@github.com:angular/bad#{symbol}name.git")
         }.to raise_error(RemoteServer::UnknownUrlFormat)

--- a/spec/lib/remote_server/stash_spec.rb
+++ b/spec/lib/remote_server/stash_spec.rb
@@ -120,7 +120,7 @@ describe RemoteServer::Stash do
     end
 
     it 'should not allow characters disallowed by Github in repository names' do
-      %w(! @ # $ % ^ & * ( ) = + \ | ` ~ [ ] { } : ; ' " ?).each do |symbol|
+      %w(! @ # $ % ^ & * ( ) = + \ | ` ~ [ ] { } : ; ' " ? /).each do |symbol|
         expect {
           make_server("git@stash.example.com:angular/bad#{symbol}name.git")
         }.to raise_error(RemoteServer::UnknownUrlFormat)


### PR DESCRIPTION
The stash remote server mistakenly allowed a url in the format: `ssh://git@stash.example.com/scm/ns/repo_name.git`