### PR TITLE
Fix CII-348: Show all convergence branches in status.

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -114,7 +114,7 @@ class BranchesController < ApplicationController
   # This action returns the current build status for all of the master branches
   # in the system
   def status_report
-    @branches = Branch.includes(:repository).where(name: 'master').decorate
+    @branches = Branch.includes(:repository).where(convergence: true).decorate
   end
 
   private

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -156,5 +156,25 @@ describe BranchesController do
         expect(element['activity']).to eq('CheckingModifications')
       end
     end
+
+    context "with extra convergence branch and one non-convergence" do
+      before do 
+        FactoryGirl.create(:branch, :name => 'feature-branch', convergence: false, repository: repository)
+        FactoryGirl.create(:branch, :name => 'convergence', convergence: true, repository: repository)
+      end
+
+      it "should include all of the convergence branches" do
+        branch ## Explicitly reference the branch to cause it to load
+
+        get :status_report, format: :xml
+
+        expect(response).to be_success
+
+        doc = Nokogiri::XML(response.body)
+        elements = doc.xpath("/Projects/Project[@name='#{repository.to_param}']")
+
+        expect(elements).to have(2).items
+      end
+    end
   end
 end


### PR DESCRIPTION
Now that non-master branches can be marked convergence,
all of them need to be shown in the status.