### PR TITLE
Fix CII-466: Add the branch name to non-master repositories

### DIFF
--- a/app/views/branches/status_report.xml.builder
+++ b/app/views/branches/status_report.xml.builder
@@ -2,7 +2,7 @@ xml.Projects do
   @branches.each do |branch|
     # currently cimonitor only utilizes the activity attribute
     xml.Project({
-      :name => branch.repository.to_param,
+      :name => branch.repository.to_param + (branch.name == 'master' ? '' : ('/' + branch.name)),
       :activity => build_activity(branch.builds.last),
       :lastBuildLabel => branch.builds.last.object_id,
       :webUrl => repository_branch_url(branch.repository, branch),

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -171,9 +171,13 @@ describe BranchesController do
         expect(response).to be_success
 
         doc = Nokogiri::XML(response.body)
-        elements = doc.xpath("/Projects/Project[@name='#{repository.to_param}']")
+        elements = doc.xpath("/Projects/Project")
 
         expect(elements).to have(2).items
+
+        names = elements.map{ |e| e.attribute("name").to_s }
+
+        expect(names).to match_array(["#{repository.to_param}", "#{repository.to_param}/convergence"])
       end
     end
   end


### PR DESCRIPTION
This makes the project name unique, which seems more in-line with the de-facto CCTray spec