### PR TITLE
fix Branch show action caching

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -25,11 +25,6 @@ class BranchesController < ApplicationController
       end
     end
 
-    if params[:format] == 'rss'
-      # remove recent builds that are pending or in progress (cimonitor expects this)
-      @builds = @builds.drop_while {|build| [:partitioning, :runnable, :running].include?(build.state) }
-    end
-
     @branch = @branch.decorate
 
     respond_to do |format|

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -1,6 +1,7 @@
 class BranchesController < ApplicationController
   caches_action :show, :cache_path => proc { |c|
-    updated_at = Branch.where(:name => params[:id]).select(:updated_at).first!.updated_at
+    load_repository_and_branch
+    updated_at = @branch.updated_at
     { :modified => updated_at.to_i }
   }
 
@@ -111,7 +112,7 @@ class BranchesController < ApplicationController
 
   # GET /XmlStatusReport.aspx
   #
-  # This action returns the current build status for all of the master branches
+  # This action returns the current build status for all of the convergence branches
   # in the system
   def status_report
     @branches = Branch.includes(:repository).where(convergence: true).decorate
@@ -126,6 +127,6 @@ class BranchesController < ApplicationController
 
   def load_repository_and_branch
     @repository || load_repository
-    @branch = @repository.branches.where(name: params[:id]).first!
+    @branch ||= @repository.branches.where(name: params[:id]).first!
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -5,6 +5,7 @@ require 'remote_server'
 # through the RemoteServer classes.
 class Repository < ActiveRecord::Base
   has_many :branches, :dependent => :destroy
+  has_many :convergence_branches, -> { where(convergence: true) }, class_name: "Branch"
   validates_presence_of :host, :name, :url
   validates_uniqueness_of :name
   validates_numericality_of :timeout, :only_integer => true


### PR DESCRIPTION
The action_cache was not scoping to Repository so this was pulling the updated_at timestamp of the first branch with that name and using that. >_<