### PR TITLE
Do not fail PollRepositoriesJob on Stash auth failure

### DIFF
--- a/app/jobs/poll_repositories_job.rb
+++ b/app/jobs/poll_repositories_job.rb
@@ -5,8 +5,8 @@ class PollRepositoriesJob
 
       begin
         head = repo.sha_for_branch(branch.name)
-      rescue RemoteServer::RefDoesNotExist, Zlib::BufError => e
-        Rails.logger.info("[PollRepositoriesJob] Exception #{e} occurred for repo #{repo.id}:#{repo.name}")
+      rescue RemoteServer::AccessDenied, RemoteServer::RefDoesNotExist, Zlib::BufError => e
+        Rails.logger.error("[PollRepositoriesJob] Exception #{e} occurred for repo #{repo.id}:#{repo.name}")
         next
       end
 

--- a/lib/remote_server.rb
+++ b/lib/remote_server.rb
@@ -5,6 +5,17 @@ module RemoteServer
   UnknownGitServer = Class.new(RuntimeError)
   UnknownUrlFormat = Class.new(RuntimeError)
   RefDoesNotExist = Class.new(RuntimeError)
+  class AccessDenied < StandardError
+    def initialize(url, action, original_message = nil)
+      @url = url
+      @action = action
+      @original_message = original_message
+    end
+
+    def to_s
+      "Authorization failure when attempting to call #{@url} via #{@action}"
+    end
+  end
 
   def self.for_url(url)
     server = Settings.git_server(url)

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -254,8 +254,12 @@ module RemoteServer
           body = response.body
           Rails.logger.info("Stash response: #{response.inspect}")
           Rails.logger.info("Stash response body: #{body.inspect}")
-          unless response.is_a? Net::HTTPSuccess
-            raise "#{response.class} body: #{body}"
+          unless response.is_a?(Net::HTTPSuccess)
+            if response.is_a?(Net::HTTPUnauthorized)
+              raise RemoteServer::AccessDenied.new(url, method, body)
+            else
+              raise "#{response.class} body: #{body}"
+            end
           end
         end
         body


### PR DESCRIPTION
If Kochiku loses permission to a Stash repository it will currently hard fail out of the PollRepositoriesJob. With this change it will log the error and continue on to the other repositories it watches.

Could obviously use some tests...