### PR TITLE
Add overall build passing statistics to build health page

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -202,6 +202,10 @@ h3
   .label
     cursor: help
 
+.build-stats
+  margin-bottom: 2em
+  width: 700px
+
 #plot
   margin-bottom: 2em
   min-width: 1000px

--- a/app/views/branches/health.html.haml
+++ b/app/views/branches/health.html.haml
@@ -26,6 +26,32 @@
       %span.number= rate
       %span.label pass rate on first try
 
+  .stats
+    %h2.subheader Build statistics
+    %p= "Build created on #{@first_built_date.strftime("%Y-%m-%d")}"
+    %table.build-stats
+      %thead
+        %tr
+          %th
+          %th Total
+          %th Failures
+          %th Pass Rate
+        %tr
+          %td= "All Time (#{@days_since_first_build} days)"
+          %td= @total_build_count
+          %td= @total_failure_count
+          %td= "#{@total_pass_rate}%"
+        %tr
+          %td Past 30 days
+          %td= @last30_build_count
+          %td= @last30_failure_count
+          %td= "#{@last30_pass_rate}%"
+        %tr
+          %td Past 7 days
+          %td= @last7_build_count
+          %td= @last7_failure_count
+          %td= "#{@last7_pass_rate}%"
+
 - if @part_climate.count > 0
   %h2.subheader= "#{@repository.name}/#{@branch.name} part failure stats over #{@builds.count} builds"
   %table.project-part-info


### PR DESCRIPTION
This will add overall build stats to the health page for total number of builds, how many builds have failed and what the passing percentage rate is. 