### PR TITLE
on_success_script changes

### DIFF
--- a/lib/build_strategies/production_build_strategy.rb
+++ b/lib/build_strategies/production_build_strategy.rb
@@ -24,7 +24,7 @@ class BuildStrategy
     end
 
     def run_success_script(build)
-      GitRepo.inside_copy(build.repository, build.ref) do
+      GitRepo.inside_repo(build.repository) do
         command = Cocaine::CommandLine.new(on_success_command(build), "", :expected_outcodes => 0..255)
         output = command.run
         output += "\nExited with status: #{command.exit_status}"

--- a/lib/build_strategies/production_build_strategy.rb
+++ b/lib/build_strategies/production_build_strategy.rb
@@ -25,7 +25,8 @@ class BuildStrategy
 
     def run_success_script(build)
       GitRepo.inside_repo(build.repository) do
-        command = Cocaine::CommandLine.new(on_success_command(build), "", :expected_outcodes => 0..255)
+        # stderr is redirected to stdout so that all output is captured in the log
+        command = Cocaine::CommandLine.new(on_success_command(build), "2>&1", expected_outcodes: 0..255)
         output = command.run
         output += "\nExited with status: #{command.exit_status}"
         script_log = FilelessIO.new(output)

--- a/spec/lib/build_strategies/production_build_strategy_spec.rb
+++ b/spec/lib/build_strategies/production_build_strategy_spec.rb
@@ -115,7 +115,6 @@ describe BuildStrategy do
     }
 
     before do
-      allow(GitRepo).to receive(:inside_copy).and_yield
       expect(build).to receive(:on_success_script).and_return("./this_is_a_triumph")
     end
 


### PR DESCRIPTION
All uses of on_success_script so far have been to push additional branches based on the contents of the commit. `inside_repo` has access to the remote whereas `inside_copy` does not.

WARNING: This is a *breaking change* if you are currently using a on_success_script. Kochiku will no longer run on_success_script with the working directory checked out to the commit that was built. Instead, the script is run from inside a git checkout of the repo but it should be treated as bare repo. Avoid accessing files on the file system and instead rely solely on git commands.