### PR TITLE
Changes to local caching of repositories

### DIFF
--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -35,7 +35,7 @@ class BuildPart < ActiveRecord::Base
       "build_ref" => build_instance.ref,
       "branch" => build_instance.branch_record.name,
       "test_files" => paths,
-      "repo_name" => repository.repo_cache_name,
+      "repo_name" => "#{repository.name}-cache",  # need to pass -cache for now for compatibility with current kochiku-worker
       "test_command" => build_instance.test_command,
       "repo_url" => repository.url_for_fetching,
       "remote_name" => "origin",

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -55,7 +55,7 @@ class Repository < ActiveRecord::Base
   delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, to: :remote_server
 
   def repo_cache_name
-    repo_cache_dir || "#{name}-cache"
+    "#{name}-cache"
   end
 
   def promotion_refs

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -54,10 +54,6 @@ class Repository < ActiveRecord::Base
 
   delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, to: :remote_server
 
-  def repo_cache_name
-    "#{name}-cache"
-  end
-
   def promotion_refs
     on_green_update.split(",").map(&:strip).reject(&:blank?)
   end

--- a/db/migrate/20151111080255_remove_repo_cache_dir_from_repositories.rb
+++ b/db/migrate/20151111080255_remove_repo_cache_dir_from_repositories.rb
@@ -1,0 +1,5 @@
+class RemoveRepoCacheDirFromRepositories < ActiveRecord::Migration
+  def change
+    remove_column :repositories, :repo_cache_dir, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150719130110) do
+ActiveRecord::Schema.define(version: 20151111080255) do
 
   create_table "branches", force: :cascade do |t|
     t.integer  "repository_id", limit: 4,                   null: false
@@ -100,7 +100,6 @@ ActiveRecord::Schema.define(version: 20150719130110) do
     t.boolean  "run_ci"
     t.boolean  "build_pull_requests"
     t.string   "on_green_update",             limit: 255
-    t.string   "repo_cache_dir",              limit: 255
     t.boolean  "send_build_failure_email",                default: true,  null: false
     t.integer  "timeout",                     limit: 4,   default: 40
     t.string   "name",                        limit: 255,                 null: false

--- a/lib/build_strategies/production_build_strategy.rb
+++ b/lib/build_strategies/production_build_strategy.rb
@@ -24,7 +24,7 @@ class BuildStrategy
     end
 
     def run_success_script(build)
-      GitRepo.inside_repo(build.repository) do
+      GitRepo.inside_copy(build.repository, build.ref) do
         # stderr is redirected to stdout so that all output is captured in the log
         command = Cocaine::CommandLine.new(on_success_command(build), "2>&1", expected_outcodes: 0..255)
         output = command.run
@@ -37,7 +37,8 @@ class BuildStrategy
     end
 
     def merge_ref(build)
-      GitRepo.inside_repo(build.repository) do
+      # If only Stash is used this could be just inside_repo
+      GitRepo.inside_copy(build.repository, "master") do
         begin
           emails = GitBlame.emails_in_branch(build)
           merger = build.repository.remote_server.merge_executor.new(build)

--- a/lib/git_merge_executor.rb
+++ b/lib/git_merge_executor.rb
@@ -6,8 +6,8 @@ class GitMergeExecutor
   class GitPushFailedError < StandardError; end
 
   def initialize(build)
-    if build.branch_record.blank?
-      raise "GitMergeExecutor requires a Build associated with a git branch"
+    if build.branch_record.convergence?
+      raise "attempted to merge #{build.branch_record.name} which is a convergence branch and is ineligible for merge by Kochiku"
     end
     @build = build
   end

--- a/lib/git_repo.rb
+++ b/lib/git_repo.rb
@@ -13,8 +13,7 @@ class GitRepo
       synchronize_cache_repo(cached_repo_path)
 
       Dir.mktmpdir(nil, WORKING_DIR) do |dir|
-        # clone local repo (fast!)
-        Cocaine::CommandLine.new("git clone", "#{cached_repo_path} #{dir}").run
+        Cocaine::CommandLine.new("git clone", "--config remote.origin.pushurl=#{repo.url} #{cached_repo_path} #{dir}").run
 
         Dir.chdir(dir) do
           raise RefNotFoundError, "repo:#{repository.url}, sha:#{sha}" unless system("git rev-list --quiet -n1 #{sha}")
@@ -75,7 +74,7 @@ class GitRepo
       cached_repo_path = WORKING_DIR.join(repository.repo_cache_name)
 
       if !cached_repo_path.directory?
-        clone_repo(repository, cached_repo_path)
+        clone_bare_repo(repository, cached_repo_path)
       else
         harmonize_remote_url(cached_repo_path, repository.url_for_fetching)
       end
@@ -102,11 +101,11 @@ class GitRepo
       end
     end
 
-    def clone_repo(repo, cached_repo_path)
+    def clone_bare_repo(repo, cached_repo_path)
       # Note: the --config option was added in git 1.7.7
       Cocaine::CommandLine.new(
         "git clone",
-        "--recursive --config remote.origin.pushurl=#{repo.url} #{repo.url_for_fetching} #{cached_repo_path}"
+        "--bare --quiet --config remote.origin.pushurl=#{repo.url} #{repo.url_for_fetching} #{cached_repo_path}"
       ).run
     end
 

--- a/lib/git_repo.rb
+++ b/lib/git_repo.rb
@@ -71,9 +71,10 @@ class GitRepo
     end
 
     def cached_repo_for(repository)
-      cached_repo_path = WORKING_DIR.join(repository.repo_cache_name)
+      cached_repo_path = WORKING_DIR.join(repository.namespace, "#{repository.name}.git")
 
       if !cached_repo_path.directory?
+        FileUtils.mkdir_p(WORKING_DIR.join(repository.namespace))
         clone_bare_repo(repository, cached_repo_path)
       else
         harmonize_remote_url(cached_repo_path, repository.url_for_fetching)

--- a/lib/git_repo.rb
+++ b/lib/git_repo.rb
@@ -72,9 +72,9 @@ class GitRepo
     end
 
     def cached_repo_for(repository)
-      cached_repo_path = File.join(WORKING_DIR, repository.repo_cache_name)
+      cached_repo_path = WORKING_DIR.join(repository.repo_cache_name)
 
-      if !File.directory?(cached_repo_path)
+      if !cached_repo_path.directory?
         clone_repo(repository, cached_repo_path)
       else
         harmonize_remote_url(cached_repo_path, repository.url_for_fetching)

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -131,7 +131,7 @@ module RemoteServer
       if success
         Rails.logger.info("Request to stash to merge PR #{pr_id} for branch #{branch} succeeded.")
       else
-        Rails.logger.info("Request to stash to merge PR #{pr_id} for branch #{branch} failed.")
+        Rails.logger.warn("Request to stash to merge PR #{pr_id} for branch #{branch} failed.")
       end
 
       success

--- a/lib/stash_merge_executor.rb
+++ b/lib/stash_merge_executor.rb
@@ -5,9 +5,6 @@ class StashMergeExecutor < GitMergeExecutor
 
   # Merges the branch associated with a build using the Stash REST api.
   def merge_and_push
-    # builds on convergence branches are ineligible for merge
-    return if @build.branch_record.convergence?
-
     remote_server = @build.repository.remote_server
     Rails.logger.info("Trying to merge branch #{@build.branch_record.name} after build id #{@build.id} using Stash REST api")
     merge_success = remote_server.merge(@build.branch_record.name)

--- a/spec/lib/build_strategies/production_build_strategy_spec.rb
+++ b/spec/lib/build_strategies/production_build_strategy_spec.rb
@@ -8,12 +8,15 @@ describe BuildStrategy do
 
   before(:each) do
     CommandStubber.new # ensure Open3 is stubbed
-    allow(GitRepo).to receive(:inside_repo).and_yield
 
     expect(Rails.application.config.action_mailer.delivery_method).to eq(:test)
   end
 
   describe "#merge_ref" do
+    before do
+      allow(GitRepo).to receive(:inside_copy).and_yield
+    end
+
     context "when auto_merge is enabled" do
       before do
         expect(GitBlame).to receive(:emails_in_branch).with(an_instance_of(Build)).and_return("the-committers@example.com")
@@ -73,6 +76,10 @@ describe BuildStrategy do
   describe "#promote_build" do
     subject { described_class.promote_build(build) }
 
+    before do
+      allow(GitRepo).to receive(:inside_repo).and_yield
+    end
+
     context "when the ref is an ancestor" do
       before(:each) {
         expect(GitRepo).to receive(:included_in_promotion_ref?).and_return(true)
@@ -115,6 +122,7 @@ describe BuildStrategy do
     }
 
     before do
+      allow(GitRepo).to receive(:inside_copy).and_yield
       expect(build).to receive(:on_success_script).and_return("./this_is_a_triumph")
     end
 

--- a/spec/lib/stash_merge_executor_spec.rb
+++ b/spec/lib/stash_merge_executor_spec.rb
@@ -38,9 +38,8 @@ describe StashMergeExecutor do
     context "for a build on a convergence branch" do
       let(:branch) { FactoryGirl.create(:convergence_branch, repository: repository) }
 
-      it "should do nothing" do
-        expect(stash_build.repository.remote_server).to_not receive(:merge)
-        subject
+      it "should raise an exception" do
+        expect { subject }.to raise_error(/ineligible for merge/)
       end
     end
   end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -154,11 +154,6 @@ describe Repository do
 
   context "#repo_cache_name" do
     it "returns the cache from the settings or the default from the repo name" do
-      repository = Repository.new(:repo_cache_dir => "foobar")
-      expect(repository.repo_cache_name).to eq("foobar")
-    end
-
-    it "returns the cache from the settings or the default from the repo name" do
       repository = Repository.new(url: "https://git.example.com/square/kochiku")
       repository.valid?
       expect(repository.repo_cache_name).to eq("kochiku-cache")

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -152,14 +152,6 @@ describe Repository do
     end
   end
 
-  context "#repo_cache_name" do
-    it "returns the cache from the settings or the default from the repo name" do
-      repository = Repository.new(url: "https://git.example.com/square/kochiku")
-      repository.valid?
-      expect(repository.repo_cache_name).to eq("kochiku-cache")
-    end
-  end
-
   context "#run_ci=" do
     it "converts the checkbox to bool" do
       repository = FactoryGirl.create(:repository)


### PR DESCRIPTION
1. Stopped initializing+cloning of git submodules of repositories for during partitioning. If a repository keeps their tests inside submodules the tests will no longer be visible to Kochiku for partitioning purposes. This is something I did not feel was important to support.

2. Clone repositories as bare repos instead of full checkouts. This has a couple benefits which are outlined in 1a742edb.

3. Clone repositories into folders mapped to their namespace. E.g. square/kochiku would be cloned into `build-partition/square/kochiku.git` instead of `build-partition/kochiku-cache`. This allows us to avoid collisions with two repositories that have the same name.

@jlintern @cheister 