### PR TITLE
Reorder branches index display

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -5,10 +5,12 @@ class BranchesController < ApplicationController
     { :modified => updated_at.to_i }
   }
 
-  # lists all of the branches for a repository
+  # lists all convergence branches as well the 100 most recently active
+  # branches
   def index
     load_repository
-    @branches = @repository.branches
+    @convergence_branches = @repository.branches.where(convergence: true)
+    @recently_active_branches = @repository.branches.where(convergence: false).order('updated_at DESC').limit(100)
   end
 
   def show

--- a/app/views/branches/index.html.haml
+++ b/app/views/branches/index.html.haml
@@ -4,6 +4,9 @@
 
 .projects
   %ul
-    - @branches.each do |branch|
-      %li.build-info{:class => ("bold" if branch.convergence?)}
+    - @convergence_branches.each do |branch|
+      %li.build-info{class: 'bold'}
+        = link_to(branch.name, repository_branch_path(branch.repository, branch))
+    - @recently_active_branches.each do |branch|
+      %li.build-info
         = link_to(branch.name, repository_branch_path(branch.repository, branch))

--- a/db/migrate/20151114185514_fix_convergence_index.rb
+++ b/db/migrate/20151114185514_fix_convergence_index.rb
@@ -1,0 +1,9 @@
+# In order for the index on convergence col to be useful it needs to be
+# namespaced by repository_id
+class FixConvergenceIndex < ActiveRecord::Migration
+  def change
+    # Add the new index first to avoid killing performance
+    add_index :branches, [:repository_id, :convergence]
+    remove_index :branches, :convergence
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151111080255) do
+ActiveRecord::Schema.define(version: 20151114185514) do
 
   create_table "branches", force: :cascade do |t|
     t.integer  "repository_id", limit: 4,                   null: false
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20151111080255) do
     t.datetime "updated_at",                                null: false
   end
 
-  add_index "branches", ["convergence"], name: "index_branches_on_convergence", using: :btree
+  add_index "branches", ["repository_id", "convergence"], name: "index_branches_on_repository_id_and_convergence", using: :btree
   add_index "branches", ["repository_id", "name"], name: "index_branches_on_repository_id_and_name", unique: true, using: :btree
 
   create_table "build_artifacts", force: :cascade do |t|

--- a/spec/controllers/branches_controller_spec.rb
+++ b/spec/controllers/branches_controller_spec.rb
@@ -6,13 +6,14 @@ describe BranchesController do
 
   describe "#index" do
     let(:repo) { FactoryGirl.create(:repository) }
-    let!(:a) { FactoryGirl.create(:branch, name: 'aster', repository: repo) }
+    let!(:a) { FactoryGirl.create(:branch, name: 'aster', repository: repo, convergence: true) }
     let!(:b) { FactoryGirl.create(:branch, name: 'buckeye', repository: repo) }
     let!(:c) { FactoryGirl.create(:branch, name: 'creosote', repository: repo) }
 
     it "shows branches in order" do
       get :index, repository_path: repo
-      expect(assigns(:branches).map(&:name)).to eq(%w{aster buckeye creosote})
+      expect(assigns(:convergence_branches).map(&:name)).to eq(%w{aster})
+      expect(assigns(:recently_active_branches).map(&:name)).to eq(%w{buckeye creosote})
     end
   end
 
@@ -158,7 +159,7 @@ describe BranchesController do
     end
 
     context "with extra convergence branch and one non-convergence" do
-      before do 
+      before do
         FactoryGirl.create(:branch, :name => 'feature-branch', convergence: false, repository: repository)
         FactoryGirl.create(:branch, :name => 'convergence', convergence: true, repository: repository)
       end


### PR DESCRIPTION
* List all convergence branches first
* List the 100 most recently active branches after that

Currently we are listing all branches which makes the page page is slow and unwieldy for large projects that have built thousands of branches.