### PR TITLE
Include status in JSON representation of build_part

### DIFF
--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -97,7 +97,7 @@ class BuildPart < ActiveRecord::Base
   end
 
   def as_json(options={})
-    super(options.merge(methods: :status))
+    super(options.reverse_merge(methods: :status))
   end
 
   def should_reattempt?

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -96,6 +96,10 @@ class BuildPart < ActiveRecord::Base
     end
   end
 
+  def as_json(options={})
+    super(options.merge(methods: :status))
+  end
+
   def should_reattempt?
     if (build_attempts.unsuccessful.count - 1) < retry_count
       true

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -233,7 +233,7 @@ describe BuildPart do
         FactoryGirl.create(:build_attempt, :build_part => build_part, :state => :passed)
       end
 
-      it "should be included in as_json" do
+      it "includes synthetic attributes like status" do
         expect(json[:status]).to eq(:passed)
       end
     end

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -225,4 +225,17 @@ describe BuildPart do
       end
     end
   end
+
+  describe "#as_json" do
+    subject(:json) { build_part.as_json['build_part'].with_indifferent_access }
+    context "with a build attempt" do
+      before do
+        FactoryGirl.create(:build_attempt, :build_part => build_part, :state => :passed)
+      end
+
+      it "should be included in as_json" do
+        expect(json[:status]).to eq(:passed)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is useful for computing a build's status in a less cached way than kochiku itself.

@robolson @cheister 