### PR TITLE
Fix BuildsController#health page errors when missing data

### DIFF
--- a/app/views/branches/health.html.haml
+++ b/app/views/branches/health.html.haml
@@ -28,7 +28,8 @@
 
   .stats
     %h2.subheader Build statistics
-    %p= "Build created on #{@first_built_date.strftime("%Y-%m-%d")}"
+    - if @first_built_date
+      %p= "First build created on #{@first_built_date.strftime("%Y-%m-%d")}"
     %table.build-stats
       %thead
         %tr


### PR DESCRIPTION
The health page will error if there hasn't been a new build within the last 7 days.