### PR TITLE
Change the default retry_count for MavenPartitioner to 0

### DIFF
--- a/lib/partitioner/maven.rb
+++ b/lib/partitioner/maven.rb
@@ -154,7 +154,7 @@ module Partitioner
         'type' => 'maven',
         'files' => mvn_modules.sort!,
         'queue' => queue,
-        'retry_count' => @options.fetch('retry_count', 2)
+        'retry_count' => @options.fetch('retry_count', 0)
       }
     end
 


### PR DESCRIPTION
It never made sense for the default to be 2 for the MavenPartitioner but 0 for the default Partitioner.