### PR TITLE
Cache XmlStatusReport.aspx endpoint

### DIFF
--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -5,6 +5,8 @@ class BranchesController < ApplicationController
     { :modified => updated_at.to_i }
   }
 
+  caches_action :status_report, expires_in: 15.seconds
+
   # lists all convergence branches as well the 100 most recently active
   # branches
   def index

--- a/app/controllers/branches_controller.rb
+++ b/app/controllers/branches_controller.rb
@@ -1,8 +1,7 @@
 class BranchesController < ApplicationController
-  caches_action :show, cache_path: proc {
+  caches_action :show, :build_time_history, cache_path: proc {
     load_repository_and_branch
-    updated_at = @branch.updated_at
-    { :modified => updated_at.to_i }
+    { :modified => @branch.updated_at.to_i }
   }
 
   caches_action :status_report, expires_in: 15.seconds
@@ -101,13 +100,9 @@ class BranchesController < ApplicationController
   def build_time_history
     load_repository_and_branch
 
-    history_json = Rails.cache.fetch("build-time-history-#{@branch.id}-#{@branch.updated_at}") do
-      @branch.decorate.build_time_history.to_json
-    end
-
     respond_to do |format|
       format.json do
-        render :json => history_json
+        render json: @branch.decorate.build_time_history.to_json
       end
     end
   end


### PR DESCRIPTION
Since it is very expensive to invalidate this cache whenever on of the effected repositories is updated we'll instead just cache it for 15 seconds. It is tolerable for the data to be 15 seconds behind (max).

The reason this endpoint needs caching is because it can be expensive to calculate if you have many repositories and several people running ccmenu (or similar program) at the same time.