### PR TITLE
Switch to the JSON serializer for Readthis

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Kochiku::Application.configure do
   # config.cache_store = :readthis_store, {
   #   expires_in: 2.days.to_i,
   #   namespace: 'cache',
-  #   marshal: Readthis::Passthrough,
+  #   marshal: JSON
   #   redis: {
   #     host: Settings.redis_host,
   #     port: Settings.redis_port,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ Kochiku::Application.configure do
   config.cache_store = :readthis_store, {
     expires_in: 2.days.to_i,
     namespace: 'cache',
-    marshal: Readthis::Passthrough,
+    marshal: JSON,
     redis: {
       host: Settings.redis_host,
       port: Settings.redis_port,

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,7 +10,7 @@ Kochiku::Application.configure do
   config.cache_store = :readthis_store, {
     expires_in: 2.days.to_i,
     namespace: 'cache',
-    marshal: Readthis::Passthrough,
+    marshal: JSON,
     redis: {
       host: Settings.redis_host,
       port: Settings.redis_port,


### PR DESCRIPTION
I should have gone with this originally instead of Passthrough.

This will give Kochiku the flexibility to store basic ruby objects like arrays and hashes into the cache.