### PR TITLE
Perform less aggressive updating of Build#updated_at

### DIFF
--- a/app/jobs/build_state_update_job.rb
+++ b/app/jobs/build_state_update_job.rb
@@ -12,6 +12,8 @@ class BuildStateUpdateJob < JobBase
 
   def perform
     build = Build.find(@build_id)
+
+    # notify github/stash that the build status has changed
     build.update_commit_status!
 
     # trigger another build for this branch if there is unbuilt commits

--- a/app/models/build_attempt.rb
+++ b/app/models/build_attempt.rb
@@ -25,8 +25,16 @@ class BuildAttempt < ActiveRecord::Base
 
     build = build_part.build_instance
     previous_state, new_state = build.update_state_from_parts!
-    Rails.logger.info("Build #{build.id} state is now #{build.state}")
-    BuildStateUpdateJob.enqueue(build.id) if previous_state != new_state
+
+    if previous_state == new_state
+      # bump build's update_at because update_state_from_parts did not alter the build record
+      build.touch
+    end
+
+    if previous_state != new_state
+      Rails.logger.info("Build #{build.id} state is now #{build.state}")
+      BuildStateUpdateJob.enqueue(build.id)
+    end
 
     true
   end
@@ -45,8 +53,16 @@ class BuildAttempt < ActiveRecord::Base
     build = build_part.build_instance
 
     previous_state, new_state = build.update_state_from_parts!
-    Rails.logger.info("Build #{build.id} state is now #{build.state}")
-    BuildStateUpdateJob.enqueue(build.id) if previous_state != new_state
+
+    if previous_state == new_state
+      # bump build's update_at because update_state_from_parts did not alter the build record
+      build.touch
+    end
+
+    if previous_state != new_state
+      Rails.logger.info("Build #{build.id} state is now #{build.state}")
+      BuildStateUpdateJob.enqueue(build.id)
+    end
 
     true
   end

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -1,6 +1,6 @@
 class BuildPart < ActiveRecord::Base
   # using 'build_instance' instead of 'build' because AR defines `build` for associations, and it wins
-  belongs_to :build_instance, :class_name => "Build", :foreign_key => "build_id", :inverse_of => :build_parts, :touch => true
+  belongs_to :build_instance, :class_name => "Build", :foreign_key => "build_id", :inverse_of => :build_parts
   has_many :build_attempts, :dependent => :destroy, :inverse_of => :build_part
   symbolize :queue
   validates_presence_of :kind, :paths, :queue


### PR DESCRIPTION
When Builds have a huge number of build_parts, the builds table could
receive a huge number of queries to bump updated_at due to the automatic
`touch` line. Remove that in favor of manually bumping Build#updated_at in
a few places where it is needed.