### PR TITLE
Rebuild action cache bug

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -281,12 +281,6 @@ class Build < ActiveRecord::Base
     end
   end
 
-  def running!
-    if [:runnable, :partitioning].include?(self.state)
-      update_attributes!(:state => :running)
-    end
-  end
-
   def is_running?
     IN_PROGRESS_STATES.include?(self.state)
   end

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -15,7 +15,6 @@ class BuildPart < ActiveRecord::Base
   def create_and_enqueue_new_build_attempt!
     begin
       build_attempt = build_attempts.create!(:state => :runnable)
-      build_instance.running!
       BuildAttemptJob.enqueue_on(queue.to_s, job_args(build_attempt))
       build_attempt
     rescue GitRepo::RefNotFoundError

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -16,6 +16,7 @@ class BuildPart < ActiveRecord::Base
     begin
       build_attempt = build_attempts.create!(:state => :runnable)
       BuildAttemptJob.enqueue_on(queue.to_s, job_args(build_attempt))
+      build_instance.touch # invalidate the cache of builds#show
       build_attempt
     rescue GitRepo::RefNotFoundError
       # delete the dud build_attempt and re-raise

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe BuildPart do
   let(:repository) { FactoryGirl.create(:repository) }
   let(:branch) { FactoryGirl.create(:branch, :repository => repository) }
-  let(:build) { FactoryGirl.create(:build, :branch_record => branch) }
+  let(:build) { FactoryGirl.create(:build, :branch_record => branch, :state => :runnable) }
   let(:build_part) { FactoryGirl.create(:build_part, :paths => ["a", "b"], :kind => "spec", :build_instance => build, :queue => 'ci') }
 
   before do
@@ -15,12 +15,6 @@ describe BuildPart do
       expect {
         build_part.create_and_enqueue_new_build_attempt!
       }.to change(build_part.build_attempts, :count).by(1)
-    end
-
-    it "updates the build state to running" do
-      expect(build.state).not_to eq(:running)
-      build_part.create_and_enqueue_new_build_attempt!
-      expect(build.state).to eq(:running)
     end
 
     it "enqueues onto the queue specified in the build part" do

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -46,9 +46,10 @@ describe Build do
       expect(build.build_parts.find_by_kind('cucumber').paths).to match_array(['a', 'b'])
     end
 
-    it "should change state to running" do
-      build.partition(parts)
-      expect(build.state).to eq(:running)
+    it "should change state to runnable" do
+      expect {
+        build.partition(parts)
+      }.to change(build, :state).from(:partitioning).to(:runnable)
     end
 
     it "creates parts with options" do


### PR DESCRIPTION
add-on to #217. The build record is not being updated when the user clicks "rebuild" via the UI. This results in the view cache being stale for a while until the build attempt gets picked up by a worker.