### PR TITLE
Fix auto flashing method not found exception

### DIFF
--- a/app/jobs/job_base.rb
+++ b/app/jobs/job_base.rb
@@ -1,10 +1,4 @@
 class JobBase
-  def initialize
-    # Ensure the log is flushed, even if this job exits quickly or never
-    # exceeds the log buffer.
-    Rails.logger.auto_flushing = true
-  end
-
   class << self
     def enqueue(*args)
       Resque.enqueue(self, *args)


### PR DESCRIPTION
The method has been removed from Rails since 3.2.13