### PR TITLE
Include paths in failed email

### DIFF
--- a/app/helpers/mail_helper.rb
+++ b/app/helpers/mail_helper.rb
@@ -7,4 +7,16 @@ module MailHelper
     end
     str.html_safe
   end
+
+  def failed_build_paths(build_part)
+    paths = build_part.paths
+
+    str = if build_part.kind.include?('spec')
+            paths.map { |path| path.split('/').last }
+          else
+            paths
+          end
+
+    str.join(', ').truncate(200)
+  end
 end

--- a/app/views/build_mailer/build_break_email.html.haml
+++ b/app/views/build_mailer/build_break_email.html.haml
@@ -22,6 +22,7 @@
         %li
           = link_to("Part number #{failed_build_part.id}", repository_build_part_url(@build.repository, @build, failed_build_part))
           = failed_build_part_sentence(failed_build_part)
+        %span.broken-path{style: "font-size: smaller; color: gray;"} - #{failed_build_paths(failed_build_part)}
     %br
     - @responsible_email_and_files.each do |email, files|
       #{email} was emailed because of changes to:

--- a/lib/git_blame.rb
+++ b/lib/git_blame.rb
@@ -98,7 +98,7 @@ class GitBlame
     def parse_git_changes(output)
       output.split("::!::").each_with_object([]) do |line, git_changes|
         commit_hash, author, commit_date, commit_message = line.chomp.split("|")
-        next if commit_hash.nil?
+        next if commit_hash.nil? || commit_message.nil?
         git_changes << {:hash => commit_hash, :author => author, :date => commit_date, :message => commit_message.tr("\n", " ")}
       end
     end


### PR DESCRIPTION
<img width="1000" alt="screen shot 2016-03-30 at 14 38 04" src="https://cloud.githubusercontent.com/assets/2307188/14158733/a55bedde-f686-11e5-8158-009795665040.png">

This resolves #180
