### PR TITLE
Queue new attempts in EnforceTimeoutsJob

### DIFF
--- a/app/jobs/enforce_timeouts_job.rb
+++ b/app/jobs/enforce_timeouts_job.rb
@@ -1,3 +1,7 @@
+# The EnforceTimeoutsJob searches for BuildAttempts that were picked up by a
+# kochiku worker but never heard back from again. It compares (Time.now -
+# started_at) against the timeout value of the repository. If the maximum time
+# has elapsed, it will mark the BuildAttempt as errored and kick off a rebuild.
 class EnforceTimeoutsJob
   def self.perform
     # The EnforceTimeoutsJob runs frequently so we do not check BuildAttempts greater than 1 day old
@@ -15,8 +19,12 @@ class EnforceTimeoutsJob
         end
 
         BuildArtifact.create(:build_attempt_id => attempt.id, :log_file => message)
-        attempt.finish!(:errored)
+        attempt.update!(state: :errored, finished_at: Time.now)
         Rails.logger.error "Errored BuildAttempt:#{ attempt.id } due to timeout"
+
+        # Enqueue another BuildAttempt if this is the most recent attempt for the BuildPart
+        part = attempt.build_part
+        part.rebuild! if part.build_attempts.last == attempt
       end
     end
   end

--- a/app/models/build_part.rb
+++ b/app/models/build_part.rb
@@ -101,7 +101,9 @@ class BuildPart < ActiveRecord::Base
   end
 
   def should_reattempt?
-    if (build_attempts.unsuccessful.count - 1) < retry_count
+    if successful?
+      false
+    elsif (build_attempts.unsuccessful.count - 1) < retry_count
       true
     # automatically retry build parts that errored in less than 60 seconds
     elsif elapsed_time && elapsed_time < 60 && last_attempt.errored? &&

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -9,8 +9,8 @@ poll_repositories_for_changes:
 
 enforce_timeouts_on_attempts:
   every:
-    - "10m"
-    - :first_in: "30m"
+    - "5m"
+    - :first_in: "5m"
   class: "EnforceTimeoutsJob"
   queue: low
   args:

--- a/db/migrate/20160408214135_index_created_at_on_build_attempts.rb
+++ b/db/migrate/20160408214135_index_created_at_on_build_attempts.rb
@@ -1,0 +1,5 @@
+class IndexCreatedAtOnBuildAttempts < ActiveRecord::Migration
+  def change
+    add_index :build_attempts, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151114185514) do
+ActiveRecord::Schema.define(version: 20160408214135) do
 
   create_table "branches", force: :cascade do |t|
     t.integer  "repository_id", limit: 4,                   null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20151114185514) do
   end
 
   add_index "build_attempts", ["build_part_id"], name: "index_build_attempts_on_build_part_id", using: :btree
+  add_index "build_attempts", ["created_at"], name: "index_build_attempts_on_created_at", using: :btree
 
   create_table "build_parts", force: :cascade do |t|
     t.integer  "build_id",    limit: 4

--- a/spec/jobs/enforce_timeouts_job_spec.rb
+++ b/spec/jobs/enforce_timeouts_job_spec.rb
@@ -1,18 +1,19 @@
 require 'spec_helper'
 
 describe EnforceTimeoutsJob do
-  let(:repository) { FactoryGirl.create(:repository, :url => 'git@github.com:square/test-repo.git', :timeout => 10) }
+  let(:repo_timeout) { 10 } # minutes
+  let(:repository) { FactoryGirl.create(:repository, :url => 'git@github.com:square/test-repo.git', :timeout => repo_timeout) }
   let(:branch) { FactoryGirl.create(:branch, :repository => repository) }
   let(:build) { FactoryGirl.create(:build, :state => :runnable, :branch_record => branch) }
   let(:build_part) { FactoryGirl.create(:build_part, :build_instance => build, :kind => :cucumber, :paths => ['baz'], :queue => :ci) }
 
   subject { EnforceTimeoutsJob.perform }
 
-  it 'mark timed-out builds as errored' do
-    attempt1 = BuildAttempt.create(:build_part_id => build_part.id, :started_at => 30.minutes.ago,
-                                   :state => :running, :builder => 'test-worker')
-    attempt2 = BuildAttempt.create(:build_part_id => build_part.id, :started_at => 10.minutes.ago,
-                                   :state => :running, :builder => 'test-worker')
+  it 'should mark timed-out builds as errored' do
+    attempt1 = BuildAttempt.create(build_part_id: build_part.id, started_at: (repo_timeout + 7).minutes.ago,
+                                   state: :running, builder: 'test-worker')
+    attempt2 = BuildAttempt.create(build_part_id: build_part.id, started_at: (repo_timeout + 2).minutes.ago,
+                                   state: :running, builder: 'test-worker')
     subject
     expect(attempt1.reload.state).to be(:errored)
     expect(attempt2.reload.state).to be(:running)

--- a/spec/jobs/enforce_timeouts_job_spec.rb
+++ b/spec/jobs/enforce_timeouts_job_spec.rb
@@ -9,6 +9,11 @@ describe EnforceTimeoutsJob do
 
   subject { EnforceTimeoutsJob.perform }
 
+  before do
+    # Stub needed to test rebuild feature
+    allow(GitRepo).to receive(:load_kochiku_yml).and_return(nil)
+  end
+
   it 'should mark timed-out builds as errored' do
     attempt1 = BuildAttempt.create(build_part_id: build_part.id, started_at: (repo_timeout + 7).minutes.ago,
                                    state: :running, builder: 'test-worker')
@@ -17,5 +22,34 @@ describe EnforceTimeoutsJob do
     subject
     expect(attempt1.reload.state).to be(:errored)
     expect(attempt2.reload.state).to be(:running)
+  end
+
+  describe "automatic rebuilds" do
+    before do
+      @overdue_ba = BuildAttempt.create(build_part_id: build_part.id, started_at: (repo_timeout + 7).minutes.ago,
+                                        state: :running, builder: 'test-worker')
+    end
+
+    context "the aborted build attempt is the most recent attempt on the BuildPart" do
+      it "should rebuild" do
+        expect(build_part.build_attempts.last).to eq(@overdue_ba)
+
+        subject
+        build_part.reload
+        expect(build_part.build_attempts.last).to_not eq(@overdue_ba)
+      end
+    end
+
+    context "the aborted build attempt is not the most recent attempt on the BuildPart" do
+      before do
+        BuildAttempt.create(build_part_id: build_part.id, started_at: 2.minutes.ago,
+                            state: :running, builder: 'test-worker')
+      end
+      it "should not rebuild" do
+        expect {
+          subject
+        }.to_not change { build_part.build_attempts.count }
+      end
+    end
   end
 end

--- a/spec/models/build_part_spec.rb
+++ b/spec/models/build_part_spec.rb
@@ -225,6 +225,17 @@ describe BuildPart do
         expect(build_part.should_reattempt?).to be false
       end
     end
+
+    context "when there has already been a successful attempt" do
+      before do
+        FactoryGirl.create(:build_attempt, build_part: build_part, state: :passed)
+        FactoryGirl.create(:build_attempt, build_part: build_part, state: :failed)
+      end
+
+      it "will not reattempt" do
+        expect(build_part.should_reattempt?).to be false
+      end
+    end
   end
 
   describe "#as_json" do


### PR DESCRIPTION
Some minor changes the EnforceTimeoutsJob plus it will now queue a retry of the BuildPart when it marks a BuildAttempt as errored.