### PR TITLE
Widen the Type column in Build views

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -433,7 +433,7 @@ table
     &.ruby-version
       width: 100px
     &.type
-      width: 62px
+      width: 130px
     &.worker
       width: 100px
     &.time


### PR DESCRIPTION
This should minimize truncation of test type descriptions that exceed 62 characters in length.
![screen shot 2016-04-14 at 6 10 07 pm](https://cloud.githubusercontent.com/assets/1090229/14548510/3fe01060-026c-11e6-84e4-d034e9b92fa7.png)
