### PR TITLE
add build artifact view so as not to have to download a log to view it

### DIFF
--- a/app/controllers/build_artifacts_controller.rb
+++ b/app/controllers/build_artifacts_controller.rb
@@ -18,6 +18,10 @@ class BuildArtifactsController < ApplicationController
   def show
     build_artifact = BuildArtifact.find(params[:id])
 
-    redirect_to build_artifact.log_file.url
+    if params[:format] == 'text'
+      render text: build_artifact.log_contents
+    else
+      redirect_to build_artifact.log_file.url
+    end
   end
 end

--- a/app/helpers/build_parts_helper.rb
+++ b/app/helpers/build_parts_helper.rb
@@ -1,0 +1,9 @@
+module BuildPartsHelper
+  def basename_with_extension(path)
+    File.basename(path)
+  end
+
+  def basename_without_extension(path)
+    File.basename(path, File.extname(path))
+  end
+end

--- a/app/models/build_artifact.rb
+++ b/app/models/build_artifact.rb
@@ -8,4 +8,12 @@ class BuildArtifact < ActiveRecord::Base
 
   scope :stdout_log, -> { where(:log_file => ['stdout.log.gz', 'stdout.log']) }
   scope :error_txt, -> { where(:log_file => 'error.txt') }
+
+  def log_contents
+    if log_file.path.include? '.gz'
+      Zlib::GzipReader.new(open(log_file.path)).read
+    else
+      log_file.read
+    end
+  end
 end

--- a/app/views/build_parts/show.html.haml
+++ b/app/views/build_parts/show.html.haml
@@ -52,7 +52,10 @@
             = link_to("stdout.log (in progress)", stream_logs_path(attempt.id))
           - else
             - attempt.build_artifacts.each do |artifact|
-              = link_to File.basename(artifact.log_file.path), artifact
+              = link_to basename_without_extension(artifact.log_file.path), build_artifact_path(artifact, format: :text)
+              (
+              = link_to 'gzipped', build_artifact_path(artifact)
+              )
               %br
         %td.wrap
           - unless attempt.stopped?

--- a/spec/helpers/build_parts_helper_spec.rb
+++ b/spec/helpers/build_parts_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe BuildPartsHelper do
+  let(:test_log_gz) { '/some/path/to/test.log.gz' }
+
+  describe "#basename_with_extension" do
+    it 'returns the basename with the extension' do
+      expect(helper.basename_with_extension(test_log_gz)).to eq("test.log.gz")
+    end
+  end
+
+  describe "#basename_without_extension" do
+    it 'returns the basename without the extension' do
+      expect(helper.basename_without_extension(test_log_gz)).to eq("test.log")
+    end
+  end
+end

--- a/spec/models/build_artifact_spec.rb
+++ b/spec/models/build_artifact_spec.rb
@@ -20,4 +20,20 @@ describe BuildArtifact do
       should include(stdout_artifact)
     end
   end
+
+  describe "#log_contents" do
+    let!(:artifact)       { FactoryGirl.create :build_artifact }
+    let!(:artifact_gz) { FactoryGirl.create :build_artifact, :log_file => File.open(FIXTURE_PATH + 'stdout.log.gz') }
+
+    it "should return the log contents for a log" do
+      log_contents = artifact.log_file.read
+      expect(artifact.log_contents).to eq(log_contents)
+    end
+
+    it "should return the log contents for a gzipped log" do
+      infile = open(artifact_gz.log_file.path)
+      log_contents = Zlib::GzipReader.new(infile).read
+      expect(artifact_gz.log_contents).to eq(log_contents)
+    end
+  end
 end


### PR DESCRIPTION
Provide a link on the build artifacts page that lets users view a log in plaintext in addition to the existing download a gzipped version.

The links will look like `stdout.log ( gzipped )` with both "stdout.log" and "gzipped" being links

This is an update to an old pull #63 by @eliotk that we updated as we upgraded from an old kochiku
