### PR TITLE
change badge image url to /badge/organization/repo_name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Kochiku::Application.routes.draw do
   match '/build_attempts/:id/stream_logs' => "build_attempts#stream_logs", :via => :get, :as => :stream_logs
   match '/build_attempts/:id/stream_logs_chunk' => "build_attempts#stream_logs_chunk", :via => :get, :as => :stream_logs_chunk
   match '/pull-request-builder' => "pull_requests#build", :via => :post, :as => :pull_request_build
+  get 'badge/*repository_path', to: 'branches#badge'
 
   # Redirects for legacy urls
   get '/projects/:project_id/builds/:build_id', to: redirect('/builds/%{build_id}')
@@ -55,8 +56,6 @@ Kochiku::Application.routes.draw do
         get 'modified_time', action: "modified_time", on: :member, defaults: { format: 'json' }
       end
     end
-
-    get 'badge', to: 'branches#badge'
 
     # override branch id to allow branch name to contain both slashes and dots
     resources :branches, path: "", only: [:index, :show], constraints: { id: /.+/ } do

--- a/spec/routes_spec.rb
+++ b/spec/routes_spec.rb
@@ -2,6 +2,17 @@ require 'spec_helper'
 
 RSpec.describe "routes", :type => :routing do
 
+  describe '/badge/org_name/repo_name' do
+    specify {
+      expect(get: '/badge/org_name/repo_name?branch=moonwalker').to route_to(
+        controller: "branches",
+        action: "badge",
+        repository_path: "org_name/repo_name",
+        branch: "moonwalker"
+      )
+    }
+  end
+
   context "branches at" do
     describe '/:repository_path/:id' do
       it 'to branch show page' do


### PR DESCRIPTION
decided to go in a different direction with the format of the badge url.

Previous: `square/kochiku/badge?branch=master`
New: `badge/square/kochiku?branch=master`

cc: @SalvatoreT 