### PR TITLE
Display the build part type instead of /dev/null on health page

### DIFF
--- a/app/helpers/build_helper.rb
+++ b/app/helpers/build_helper.rb
@@ -22,7 +22,11 @@ module BuildHelper
     if (build_part.options['total_workers'] && build_part.options['worker_chunk'])
       build_part.paths.first + " - Chunk #{build_part.options['worker_chunk']} of #{build_part.options['total_workers']}"
     elsif build_part.paths.size == 1
-      build_part.paths.first
+      if build_part.paths.first == "/dev/null"
+        build_part.kind
+      else
+        build_part.paths.first
+      end
     else
       first, *rest = build_part.paths
       first = first.sub(/([^\/]+)/, '<b class="root">\1</b>')

--- a/spec/helpers/build_helper_spec.rb
+++ b/spec/helpers/build_helper_spec.rb
@@ -81,4 +81,12 @@ describe BuildHelper do
       expect(format_paths(build_part)).to eq("a - Chunk 3 of 5")
     end
   end
+
+  context "a build part with no paths (/dev/null)" do
+    let!(:build_part) { FactoryGirl.create(:build_part, build_instance: build, paths: ['/dev/null'], kind: 'lint-check') }
+
+    it "displays the BuildPart kind instead of /dev/null" do
+      expect(format_paths(build_part)).to eq("lint-check")
+    end
+  end
 end


### PR DESCRIPTION
This is for the situation when the build part does not have any paths.
The build part type is more useful information.