### PR TITLE
Fix create pull request link for Stash

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,16 +36,13 @@ module ApplicationHelper
   end
 
   def link_to_branch(build)
-    link_to(build.branch_record.name, show_link_to_branch(build.branch_record))
+    branch_record = build.branch_record
+    branch_name = branch_record.name
+    link_to(branch_name, branch_record.repository.get_branch_url(branch_name))
   end
 
   def show_link_to_commit(repo, commit_sha)
     repo.remote_server.href_for_commit(commit_sha).to_s
-  end
-
-  # TODO: Extract these links into RemoteServer
-  def show_link_to_branch(branch_record)
-    "#{branch_record.repository.base_html_url}/tree/#{branch_record.name}"
   end
 
   def show_link_to_compare(build, first_commit_hash, second_commit_hash)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -59,7 +59,7 @@ module ApplicationHelper
   end
 
   def show_link_to_create_pull_request(build)
-    "#{build.repository.base_html_url}/pull/new/master...#{build.ref}"
+    build.repository.open_pull_request_url(build.branch_record.name)
   end
 
   def timeago(time, options = {})

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -52,7 +52,7 @@ class Repository < ActiveRecord::Base
     @remote_server ||= RemoteServer.for_url(url)
   end
 
-  delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, :open_pull_request_url, to: :remote_server
+  delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, :get_branch_url, :open_pull_request_url, to: :remote_server
 
   def promotion_refs
     on_green_update.split(",").map(&:strip).reject(&:blank?)

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -52,7 +52,7 @@ class Repository < ActiveRecord::Base
     @remote_server ||= RemoteServer.for_url(url)
   end
 
-  delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, to: :remote_server
+  delegate :base_html_url, :base_api_url, :sha_for_branch, :url_for_fetching, :open_pull_request_url, to: :remote_server
 
   def promotion_refs
     on_green_update.split(",").map(&:strip).reject(&:blank?)

--- a/lib/remote_server/github.rb
+++ b/lib/remote_server/github.rb
@@ -95,6 +95,10 @@ module RemoteServer
       "https://#{attributes[:host]}/#{attributes[:repository_namespace]}/#{attributes[:repository_name]}"
     end
 
+    def get_branch_url(branch_name)
+      "#{base_html_url}/tree/#{branch_name}"
+    end
+
     def open_pull_request_url(branch_name)
       "#{base_html_url}/pull/new/master...#{branch_name}"
     end

--- a/lib/remote_server/github.rb
+++ b/lib/remote_server/github.rb
@@ -94,5 +94,9 @@ module RemoteServer
     def base_html_url
       "https://#{attributes[:host]}/#{attributes[:repository_namespace]}/#{attributes[:repository_name]}"
     end
+
+    def open_pull_request_url(branch_name)
+      "#{base_html_url}/pull/new/master...#{branch_name}"
+    end
   end
 end

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -112,11 +112,15 @@ module RemoteServer
     end
 
     def base_html_url
-      "https://#{attributes[:host]}/projects/#{attributes[:repository_namespace]}/repos/#{attributes[:repository_name]}"
+      "https://#{attributes[:host]}/projects/#{attributes[:repository_namespace].upcase}/repos/#{attributes[:repository_name]}"
     end
 
     def href_for_commit(sha)
       "#{base_html_url}/commits/#{sha}"
+    end
+
+    def open_pull_request_url(branch_name)
+      "#{base_html_url}/compare/commits?sourceBranch=refs/heads/#{branch_name}"
     end
 
     # uses the stash REST api to merge a pull request

--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -119,6 +119,10 @@ module RemoteServer
       "#{base_html_url}/commits/#{sha}"
     end
 
+    def get_branch_url(branch_name)
+      "#{base_html_url}?at=refs/heads/#{branch_name}"
+    end
+
     def open_pull_request_url(branch_name)
       "#{base_html_url}/compare/commits?sourceBranch=refs/heads/#{branch_name}"
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -92,12 +92,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#show_link_to_create_pull_request" do
-    it "creates a url to github for a pull request" do
-      expect(show_link_to_create_pull_request(@build)).to eq('https://git.example.com/square/web/pull/new/master...SHA1FORCOMMIT')
-    end
-  end
-
   describe "timeago" do
     it "should generate the correct abbr tag" do
       timestamp = Time.at(0).utc

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -57,12 +57,6 @@ describe ApplicationHelper do
     end
   end
 
-  describe "#show_link_to_branch" do
-    it "should create a url to github based on config" do
-      expect(show_link_to_branch(@build.branch_record)).to eq('https://git.example.com/square/web/tree/nomnomnom')
-    end
-  end
-
   describe "#show_link_to_compare" do
     let(:branch_stash) { FactoryGirl.create(:branch, repository: repository_stash, name: "okay") }
     let(:branch_stash_no_greenupdate) { FactoryGirl.create(:branch, repository: repository_stash_no_greenupdate, name: "okay") }
@@ -83,12 +77,12 @@ describe ApplicationHelper do
 
     it "creates a url to stash showing the diff between master and green branches" do
       build_stash = Build.new(ref: "SHA1FORCOMMIT", branch_record: branch_stash)
-      expect(show_link_to_compare(build_stash, 'SHA1FORCOMMIT', 'SHA2FORCOMMIT')).to eq('https://stash.example.com/projects/square/repos/web2/compare/commits?targetBranch=green&sourceBranch=refs%2Fheads%2Fmaster')
+      expect(show_link_to_compare(build_stash, 'SHA1FORCOMMIT', 'SHA2FORCOMMIT')).to eq('https://stash.example.com/projects/SQUARE/repos/web2/compare/commits?targetBranch=green&sourceBranch=refs%2Fheads%2Fmaster')
     end
 
     it "creates a url to stash showing a comparison with master if no green branch set" do
       build_stash_no_greenupdate = Build.new(ref: "SHA1FORCOMMIT", branch_record: branch_stash_no_greenupdate)
-      expect(show_link_to_compare(build_stash_no_greenupdate, 'SHA1FORCOMMIT', 'SHA2FORCOMMIT')).to eq('https://stash.example.com/projects/square/repos/web3/compare/commits?targetBranch=refs%2Fheads%2Fmaster')
+      expect(show_link_to_compare(build_stash_no_greenupdate, 'SHA1FORCOMMIT', 'SHA2FORCOMMIT')).to eq('https://stash.example.com/projects/SQUARE/repos/web3/compare/commits?targetBranch=refs%2Fheads%2Fmaster')
     end
   end
 

--- a/spec/lib/remote_server/github_spec.rb
+++ b/spec/lib/remote_server/github_spec.rb
@@ -108,4 +108,12 @@ describe RemoteServer::Github do
       expect(result).to eq(ssh_url)
     end
   end
+
+  describe '#open_pull_request_url' do
+    it 'should return the expected url' do
+      https_url = "https://github.com/square/test-repo1.git"
+      result = make_server(https_url).open_pull_request_url('my-new-branch')
+      expect(result).to eq("https://github.com/square/test-repo1/pull/new/master...my-new-branch")
+    end
+  end
 end

--- a/spec/lib/remote_server/github_spec.rb
+++ b/spec/lib/remote_server/github_spec.rb
@@ -109,6 +109,14 @@ describe RemoteServer::Github do
     end
   end
 
+  describe '#get_branch_url' do
+    it 'should return the expected url' do
+      https_url = "https://github.com/square/test-repo1.git"
+      result = make_server(https_url).get_branch_url('my-new-branch')
+      expect(result).to eq("https://github.com/square/test-repo1/tree/my-new-branch")
+    end
+  end
+
   describe '#open_pull_request_url' do
     it 'should return the expected url' do
       https_url = "https://github.com/square/test-repo1.git"

--- a/spec/lib/remote_server/stash_spec.rb
+++ b/spec/lib/remote_server/stash_spec.rb
@@ -169,6 +169,14 @@ describe RemoteServer::Stash do
     end
   end
 
+  describe '#open_pull_request_url' do
+    it 'should return the expected url' do
+      https_url = "https://stash.example.com/scm/foo/bar.git"
+      result = make_server(https_url).open_pull_request_url('my-new-branch')
+      expect(result).to eq("https://stash.example.com/projects/FOO/repos/bar/compare/commits?sourceBranch=refs/heads/my-new-branch")
+    end
+  end
+
   describe "#head_commit" do
     let(:https_url) { "https://stash.example.com/scm/foo/bar.git" }
     let(:server) { make_server(https_url) }

--- a/spec/lib/remote_server/stash_spec.rb
+++ b/spec/lib/remote_server/stash_spec.rb
@@ -169,6 +169,14 @@ describe RemoteServer::Stash do
     end
   end
 
+  describe '#get_branch_url' do
+    it 'should return the expected url' do
+      https_url = "https://stash.example.com/scm/foo/bar.git"
+      result = make_server(https_url).get_branch_url('my-new-branch')
+      expect(result).to eq("https://stash.example.com/projects/FOO/repos/bar?at=refs/heads/my-new-branch")
+    end
+  end
+
   describe '#open_pull_request_url' do
     it 'should return the expected url' do
       https_url = "https://stash.example.com/scm/foo/bar.git"


### PR DESCRIPTION
Kochiku has been lazily been displaying the github style url for Stash repos this whole time. Finally fixing this injustice.

Bonus: Fixed the TODO message put in the code in 2013. feelsgoodman