### PR TITLE
Fix the display of scheduled jobs after upgrade to resque-scheduler 4.3

### DIFF
--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,9 +1,14 @@
+require 'resque-scheduler'
 require 'resque-retry'
 require 'resque/failure/redis'
 require 'resque-retry/server'
 
 Resque.redis = REDIS
 Resque.redis.namespace = "resque:kochiku"
+
+# Necessary to specify the schedule file here for the scheduled jobs to appear
+# in the resque-web UI
+Resque.schedule = YAML.load_file('config/resque_schedule.yml')
 
 Resque::Failure::MultipleWithRetrySuppression.classes = [Resque::Failure::Redis]
 Resque::Failure.backend = Resque::Failure::MultipleWithRetrySuppression


### PR DESCRIPTION
After the upgrade to resque-scheduler 4.3 the scheduled jobs are running but the scheduled tab of resque-web is blank.