### PR TITLE
Allow target to be specified in kochiku.yml instead of glob #CII-1098

### DIFF
--- a/lib/partitioner/default.rb
+++ b/lib/partitioner/default.rb
@@ -84,7 +84,9 @@ module Partitioner
       queue_override = subset.fetch('queue_override', nil)
       queue = "#{queue}-#{queue_override}" if queue_override.present?
 
-      get_file_parts_for(subset).map do |part_files|
+      subset_part_files = subset['target'] ? [Array(subset['target'])] : get_file_parts_for(subset)
+
+      subset_part_files.map do |part_files|
         {'type' => type, 'files' => part_files.compact, 'queue' => queue,
          'retry_count' => retry_count, 'options' => subset['options']}
       end.select { |p| p['files'].present? }

--- a/spec/lib/partitioner/shared_default_behavior.rb
+++ b/spec/lib/partitioner/shared_default_behavior.rb
@@ -353,5 +353,48 @@ RSpec.shared_examples "Partitioner::Default behavior" do |partitioner_class|
         end
       end
     end
+
+    context 'when target is specified' do
+      let(:kochiku_yml) do
+        {
+          'targets' => [
+            {
+              'type' => 'instrumentation',
+              'target' => 'util:libraryA'
+            },
+            {
+              'type' => 'instrumentation',
+              'target' => ['util:libraryB', 'util:libraryC']
+            }
+          ]
+        }
+      end
+
+      it 'accepts both strings and arrays' do
+        expect(subject.size).to eq(2)
+        expect(subject[0]['files']).to eq(['util:libraryA'])
+        expect(subject[1]['files']).to eq(['util:libraryB', 'util:libraryC'])
+      end
+
+      context "when workers and/or glob are also specified" do
+        let(:kochiku_yml) do
+          {
+            'targets' => [
+              {
+                'type' => 'instrumentation',
+                'target' => 'util:libraryA',
+                'workers' => 10,
+                'glob' => 'spec/**/*_spec.rb'
+              }
+            ]
+          }
+        end
+
+        it 'ignores them' do
+          expect(subject.size).to eq(1)
+          expect(subject[0]['files']).to eq(['util:libraryA'])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Kochiku was originally designed for file based tests but that doesn't always translate well to Java. Instead of defining glob in kochiku.yml, target could be specified.

Example:

```
targets:

- type: instrumentation
  target: app

- type: instrumentation
  target: util:libraryA

- type: instrumentation
  target:
    - util:libraryB
    - util:libraryC
```