### PR TITLE
Change stash http requests to always use the primary host name

### DIFF
--- a/lib/remote_server/stash.rb
+++ b/lib/remote_server/stash.rb
@@ -108,11 +108,11 @@ module RemoteServer
     end
 
     def base_api_url
-      "https://#{attributes[:host]}/rest/api/1.0/projects/#{attributes[:repository_namespace]}/repos/#{attributes[:repository_name]}"
+      "https://#{@settings.host}/rest/api/1.0/projects/#{attributes[:repository_namespace]}/repos/#{attributes[:repository_name]}"
     end
 
     def base_html_url
-      "https://#{attributes[:host]}/projects/#{attributes[:repository_namespace].upcase}/repos/#{attributes[:repository_name]}"
+      "https://#{@settings.host}/projects/#{attributes[:repository_namespace].upcase}/repos/#{attributes[:repository_name]}"
     end
 
     def href_for_commit(sha)


### PR DESCRIPTION
If the alias is used kochiku will run into a http redirect. It is easier
to always use the primary host name than worry about following the
redirects.