### PR TITLE
Two projects can have the same name

### DIFF
--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -7,7 +7,8 @@ class Repository < ActiveRecord::Base
   has_many :branches, :dependent => :destroy
   has_many :convergence_branches, -> { where(convergence: true) }, class_name: "Branch"
   validates :host, :name, :url, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { scope: :namespace, message: "^Namespace + Name combination already exists",
+                                 case_sensitive: false }
   validates :timeout, numericality: { :only_integer => true }
   validates :timeout, inclusion: { in: 0..1440, message: 'The maximum timeout allowed is 1440 minutes' }
   validates :url, uniqueness: true, allow_blank: true

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -90,15 +90,24 @@ describe Repository do
           repo.valid?
           expect(repo.name).to eq("kochiku-name")
         end
+      end
+    end
 
-        context "when that name already exists" do
-          let!(:existing_repo) { FactoryGirl.create(:repository, name: 'my-repo') }
+    context "name" do
+      before do
+        @repo1 = FactoryGirl.create(:repository, url: "git@git.example.com:kansas/kansas-city.git")
+      end
 
-          it "does not validate" do
-            repo = FactoryGirl.build(:repository, name: 'my-repo')
-            expect(repo).to_not be_valid
-          end
-        end
+      it "should allow two repositories with the same name from different namespaces" do
+        repo2 = Repository.new(url: "git://git.example.com/missouri/kansas-city.git")
+        expect(repo2).to be_valid
+      end
+
+      it "should not allow two repositories with the same name and namespaces" do
+        repo2 = Repository.new(url: "git://github.com/kansas/kansas-city.git")
+        repo2.valid?
+        expect(repo2).to have(1).error_on(:name)
+        expect(repo2.errors.full_messages).to include("Namespace + Name combination already exists")
       end
     end
 


### PR DESCRIPTION
Change uniqueness check to allow two projects to have the same name as long as they have 
a different namespace.