### PR TITLE
Add assume_lost_after to repository

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -111,7 +111,8 @@ class RepositoriesController < ApplicationController
           .permit(:enabled, :url, :timeout, :build_pull_requests,
                   :run_ci, :on_green_update, :send_build_success_email,
                   :send_build_failure_email, :allows_kochiku_merges,
-                  :email_on_first_failure, :send_merge_successful_email)
+                  :email_on_first_failure, :send_merge_successful_email,
+                  :assume_lost_after)
   end
 
   # update_convergence_branches is called by both create and update. This

--- a/app/jobs/timeout_stuck_builds_job.rb
+++ b/app/jobs/timeout_stuck_builds_job.rb
@@ -1,0 +1,32 @@
+class TimeoutStuckBuildsJob < JobBase
+  @queue = :high
+
+  def self.perform
+    clean_lost_builds
+    clean_runnable_not_queued
+  end
+
+  def self.clean_runnable_not_queued
+    # check for builds in runnable that are no longer in the queue
+    missing = []
+    BuildAttempt.select("build_attempts.id", " build_parts.queue as queue").joins(:build_part)
+                .where("build_attempts.state = 'runnable' AND build_attempts.created_at < ? AND build_attempts.created_at > ?", 5.minutes.ago, 1.day.ago)
+                .group_by(&:queue)
+                .each do |queue, attempts|
+                  current_queue = Resque.redis.lrange("queue:#{queue}", 0, -1).to_s
+                  missing += attempts.reject { |attempt| current_queue.match(/build_attempt_id\\*\"\:#{attempt.id}[^0-9]/) }
+                end
+
+    missing.select! { |build_attempt_partial| BuildAttempt.find(build_attempt_partial.id).state == :runnable }
+    missing.each { |build_attempt_partial| BuildAttempt.find(build_attempt_partial.id).finish!(:errored) }
+  end
+
+  def self.clean_lost_builds
+    # check for builds that have hit their assume_lost_after
+    Repository.where("assume_lost_after IS NOT NULL").find_each do |repo|
+      repo.build_attempts.where("build_attempts.state = 'running' AND build_attempts.started_at < ?", repo.assume_lost_after.minutes.ago).each do |build_attempt|
+        build_attempt.finish!(:errored)
+      end
+    end
+  end
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -6,11 +6,15 @@ require 'remote_server'
 class Repository < ActiveRecord::Base
   has_many :branches, :dependent => :destroy
   has_many :convergence_branches, -> { where(convergence: true) }, class_name: "Branch"
+  has_many :builds, through: :branches
+  has_many :build_parts, through: :builds
+  has_many :build_attempts, through: :build_parts
   validates :host, :name, :url, presence: true
   validates :name, uniqueness: { scope: :namespace, message: "^Namespace + Name combination already exists",
                                  case_sensitive: false }
   validates :timeout, numericality: { :only_integer => true }
   validates :timeout, inclusion: { in: 0..1440, message: 'The maximum timeout allowed is 1440 minutes' }
+  validates :assume_lost_after, numericality: { :only_integer => true }, :allow_nil => true
   validates :url, uniqueness: true, allow_blank: true
   validate :validate_url_against_remote_servers
 

--- a/app/views/repositories/_form.html.haml
+++ b/app/views/repositories/_form.html.haml
@@ -15,6 +15,10 @@
     = f.text_field :timeout, :id => "timeout", :class => "short"
     minutes
   %div
+    %label{:for => "assume_lost_after"} Assume that a build has been lost if its still running after:
+    = f.text_field :assume_lost_after, :id => "assume_lost_after", :class => "short"
+    minutes
+  %div
     %label{:for => "run_ci"} Trigger build on push to master:
     = f.check_box :run_ci, :id => "run_ci"
   %div

--- a/db/migrate/20180220185338_add_assume_lost_after_to_repository.rb
+++ b/db/migrate/20180220185338_add_assume_lost_after_to_repository.rb
@@ -1,0 +1,5 @@
+class AddAssumeLostAfterToRepository < ActiveRecord::Migration
+  def change
+    add_column :repositories, :assume_lost_after, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180208202524) do
+ActiveRecord::Schema.define(version: 20180220185338) do
 
   create_table "branches", force: :cascade do |t|
     t.integer  "repository_id", limit: 4,                   null: false
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 20180208202524) do
     t.boolean  "email_on_first_failure",                  default: false, null: false
     t.boolean  "send_merge_successful_email",             default: true,  null: false
     t.boolean  "enabled",                                 default: true,  null: false
+    t.integer  "assume_lost_after",           limit: 4
   end
 
   add_index "repositories", ["host", "namespace", "name"], name: "index_repositories_on_host_and_namespace_and_name", unique: true, using: :btree

--- a/spec/jobs/timeout_stuck_builds_job_spec.rb
+++ b/spec/jobs/timeout_stuck_builds_job_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe TimeoutStuckBuildsJob do
+  let(:repository) { FactoryGirl.create(:repository, url: 'git@github.com:square/test-repo.git', assume_lost_after: 10) }
+  let(:branch) { FactoryGirl.create(:branch, :repository => repository) }
+  let(:build) { FactoryGirl.create(:build, :state => :runnable, :branch_record => branch) }
+
+  subject { TimeoutStuckBuildsJob.perform }
+
+  describe "#perform" do
+    let(:build_attempt) {
+      build.build_parts.create!(:kind => :spec, :paths => ["foo", "bar"], :queue => :ci)
+           .build_attempts.create!(:state => :running)
+    }
+    let(:build_attempt_2) {
+      build.build_parts.create!(:kind => :cucumber, :paths => ["baz"], :queue => :ci)
+           .build_attempts.create!(:state => :running)
+    }
+    context "when a repository has assume_lost_after set" do
+      it "should not stop builds that have yet to reach the limit" do
+        subject
+        expect(build_attempt.reload.state).to eq(:running)
+        expect(build_attempt_2.reload.state).to eq(:running)
+      end
+
+      it "should stop builds that have reached the limit" do
+        expect(build_attempt.state).to eq(:running)
+        build_attempt.update_attributes(started_at: 30.minutes.ago)
+        subject
+        expect(build_attempt.reload.state).to eq(:errored)
+        expect(build_attempt_2.reload.state).to eq(:running)
+      end
+    end
+
+    context "when a build attempt was created more then 5 minutes ago" do
+      let(:build_attempt) {
+        build.build_parts.create!(:kind => :cucumber, :paths => ["baz"], :queue => :ci)
+             .build_attempts.create!(:created_at => 10.minutes.ago, :state => :runnable, :builder => "test")
+      }
+
+      it "should stop a build that is not queued" do
+        expect(build_attempt.state).to eq(:runnable)
+        subject
+        expect(build_attempt.reload.state).to eq(:errored)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a timeout check for build attempts over assume_lost_after
Add a timeout check for build attempts that are runnable but not queued


does not add the job to the resque schedule by default.