### PR TITLE
Add /builds/:id/status endpoint

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -112,7 +112,8 @@ class BuildsController < ApplicationController
   end
 
   def build_status
-    @build = Build.joins(:branch_record).where('branches.repository_id' => @repository.id).find(params[:id])
+    @build = @repository ? @repository.builds.find(params[:id]) : Build.find(params[:id])
+
     respond_to do |format|
       format.json do
         render :json => @build
@@ -144,8 +145,10 @@ class BuildsController < ApplicationController
   private
 
   def load_repository
-    r_namespace, r_name = params[:repository_path].split('/')
-    @repository = Repository.where(namespace: r_namespace, name: r_name).first!
+    if params[:repository_path]
+      r_namespace, r_name = params[:repository_path].split('/')
+      @repository = Repository.where(namespace: r_namespace, name: r_name).first!
+    end
   end
 
   def format_build_parts_position

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Kochiku::Application.routes.draw do
   match '/worker_health', to: "dashboards#build_history_by_worker", via: :get, as: :build_history_by_worker
 
   match 'builds/:id' => "builds#build_redirect", :via => :get, :as => :build_redirect, :id => /\d+/
+  match 'builds/:id/status' => "builds#build_status", :via => :get, :as => :build_status, :id => /\d+/, :defaults => { :format => 'json' }
   match 'builds/:ref' => "builds#build_ref_redirect", :via => :get, :as => :build_ref_redirect
   match '/build_attempts/:build_attempt_id/build_artifacts' => "build_artifacts#create", :via => :post
   match '/build_attempts/:id/start' => "build_attempts#start", :via => :post


### PR DESCRIPTION
useful endpoint. Does not require knowing the project name, just the build ID.