### PR TITLE
Specifies Rails 5.0 as the release version for migrations

### DIFF
--- a/db/migrate/20110621212000_create_schema.rb
+++ b/db/migrate/20110621212000_create_schema.rb
@@ -1,4 +1,4 @@
-class CreateSchema < ActiveRecord::Migration[5.1]
+class CreateSchema < ActiveRecord::Migration[5.0]
   def self.up
     create_table :builds do |t|
       t.string :sha

--- a/db/migrate/20110624003418_change_artifact_type_to_name.rb
+++ b/db/migrate/20110624003418_change_artifact_type_to_name.rb
@@ -1,4 +1,4 @@
-class ChangeArtifactTypeToName < ActiveRecord::Migration[5.1]
+class ChangeArtifactTypeToName < ActiveRecord::Migration[5.0]
   def self.up
     rename_column :build_artifacts, :type, :name
   end

--- a/db/migrate/20110624015709_rename_build_part_result_result_to_state.rb
+++ b/db/migrate/20110624015709_rename_build_part_result_result_to_state.rb
@@ -1,4 +1,4 @@
-class RenameBuildPartResultResultToState < ActiveRecord::Migration[5.1]
+class RenameBuildPartResultResultToState < ActiveRecord::Migration[5.0]
   def self.up
     rename_column :build_part_results, :result, :state
   end

--- a/db/migrate/20110708203120_change_build_artifacts_for_carrier_wave.rb
+++ b/db/migrate/20110708203120_change_build_artifacts_for_carrier_wave.rb
@@ -1,4 +1,4 @@
-class ChangeBuildArtifactsForCarrierWave < ActiveRecord::Migration[5.1]
+class ChangeBuildArtifactsForCarrierWave < ActiveRecord::Migration[5.0]
   def self.up
     rename_column :build_artifacts, :name, :log_file
     remove_column :build_artifacts, :content

--- a/db/migrate/20110713175724_rename_build_part_result_to_build_part_run.rb
+++ b/db/migrate/20110713175724_rename_build_part_result_to_build_part_run.rb
@@ -1,4 +1,4 @@
-class RenameBuildPartResultToBuildPartRun < ActiveRecord::Migration[5.1]
+class RenameBuildPartResultToBuildPartRun < ActiveRecord::Migration[5.0]
   def self.up
     rename_table :build_part_results, :build_attempts
     rename_column :build_artifacts, :build_part_result_id, :build_attempt_id

--- a/db/migrate/20110713191536_add_foreign_key_indexes.rb
+++ b/db/migrate/20110713191536_add_foreign_key_indexes.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyIndexes < ActiveRecord::Migration[5.1]
+class AddForeignKeyIndexes < ActiveRecord::Migration[5.0]
   def self.up
     add_index :build_parts, :build_id
     add_index :build_attempts, :build_part_id

--- a/db/migrate/20110719204508_create_projects.rb
+++ b/db/migrate/20110719204508_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration[5.1]
+class CreateProjects < ActiveRecord::Migration[5.0]
   def self.up
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20110719205413_add_project_id_to_builds.rb
+++ b/db/migrate/20110719205413_add_project_id_to_builds.rb
@@ -1,4 +1,4 @@
-class AddProjectIdToBuilds < ActiveRecord::Migration[5.1]
+class AddProjectIdToBuilds < ActiveRecord::Migration[5.0]
   def self.up
     add_column :builds, :project_id, :integer
     add_index  :builds, :project_id

--- a/db/migrate/20110721185201_rename_builds_sha_to_ref.rb
+++ b/db/migrate/20110721185201_rename_builds_sha_to_ref.rb
@@ -1,4 +1,4 @@
-class RenameBuildsShaToRef < ActiveRecord::Migration[5.1]
+class RenameBuildsShaToRef < ActiveRecord::Migration[5.0]
   def self.up
     rename_column :builds, :sha, :ref
   end

--- a/db/migrate/20110801215540_rename_error_state_to_errored.rb
+++ b/db/migrate/20110801215540_rename_error_state_to_errored.rb
@@ -1,4 +1,4 @@
-class RenameErrorStateToErrored < ActiveRecord::Migration[5.1]
+class RenameErrorStateToErrored < ActiveRecord::Migration[5.0]
   def self.up
     execute("UPDATE build_attempts SET state='errored' WHERE state='error'")
     execute("UPDATE builds SET state='errored' WHERE state='error'")

--- a/db/migrate/20120803005242_add_merge_bool_to_build.rb
+++ b/db/migrate/20120803005242_add_merge_bool_to_build.rb
@@ -1,4 +1,4 @@
-class AddMergeBoolToBuild < ActiveRecord::Migration[5.1]
+class AddMergeBoolToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :auto_merge, :boolean
   end

--- a/db/migrate/20120817225343_add_branch_to_build.rb
+++ b/db/migrate/20120817225343_add_branch_to_build.rb
@@ -1,4 +1,4 @@
-class AddBranchToBuild < ActiveRecord::Migration[5.1]
+class AddBranchToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :branch, :string
   end

--- a/db/migrate/20121008211955_create_repositories.rb
+++ b/db/migrate/20121008211955_create_repositories.rb
@@ -1,4 +1,4 @@
-class CreateRepositories < ActiveRecord::Migration[5.1]
+class CreateRepositories < ActiveRecord::Migration[5.0]
   def change
     create_table :repositories do |t|
       t.string :url

--- a/db/migrate/20121017173936_add_github_repository_id_to_repository.rb
+++ b/db/migrate/20121017173936_add_github_repository_id_to_repository.rb
@@ -1,4 +1,4 @@
-class AddGithubRepositoryIdToRepository < ActiveRecord::Migration[5.1]
+class AddGithubRepositoryIdToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :github_post_receive_hook_id, :integer
   end

--- a/db/migrate/20121017182543_fix_repository_schema.rb
+++ b/db/migrate/20121017182543_fix_repository_schema.rb
@@ -1,4 +1,4 @@
-class FixRepositorySchema < ActiveRecord::Migration[5.1]
+class FixRepositorySchema < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :run_ci, :boolean
     add_column :repositories, :use_branches_on_green, :boolean

--- a/db/migrate/20121017184946_remove_options_from_repository.rb
+++ b/db/migrate/20121017184946_remove_options_from_repository.rb
@@ -1,4 +1,4 @@
-class RemoveOptionsFromRepository < ActiveRecord::Migration[5.1]
+class RemoveOptionsFromRepository < ActiveRecord::Migration[5.0]
   def change
     remove_column :repositories, :options
   end

--- a/db/migrate/20121017222538_add_target_name_to_builds.rb
+++ b/db/migrate/20121017222538_add_target_name_to_builds.rb
@@ -1,4 +1,4 @@
-class AddTargetNameToBuilds < ActiveRecord::Migration[5.1]
+class AddTargetNameToBuilds < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :target_name, :string
   end

--- a/db/migrate/20121017224003_add_command_flag_to_repositories.rb
+++ b/db/migrate/20121017224003_add_command_flag_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddCommandFlagToRepositories < ActiveRecord::Migration[5.1]
+class AddCommandFlagToRepositories < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :command_flag, :string
   end

--- a/db/migrate/20121018182435_add_options_to_build_part.rb
+++ b/db/migrate/20121018182435_add_options_to_build_part.rb
@@ -1,4 +1,4 @@
-class AddOptionsToBuildPart < ActiveRecord::Migration[5.1]
+class AddOptionsToBuildPart < ActiveRecord::Migration[5.0]
   def change
     add_column :build_parts, :options, :text
   end

--- a/db/migrate/20121024005715_add_send_build_failure_email_to_repository.rb
+++ b/db/migrate/20121024005715_add_send_build_failure_email_to_repository.rb
@@ -1,4 +1,4 @@
-class AddSendBuildFailureEmailToRepository < ActiveRecord::Migration[5.1]
+class AddSendBuildFailureEmailToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :send_build_failure_email, :boolean, :default => true
   end

--- a/db/migrate/20121024164929_record_build_failure_email_sent.rb
+++ b/db/migrate/20121024164929_record_build_failure_email_sent.rb
@@ -1,4 +1,4 @@
-class RecordBuildFailureEmailSent < ActiveRecord::Migration[5.1]
+class RecordBuildFailureEmailSent < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :build_failure_email_sent, :boolean
   end

--- a/db/migrate/20121024210129_add_success_script_to_repositories.rb
+++ b/db/migrate/20121024210129_add_success_script_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddSuccessScriptToRepositories < ActiveRecord::Migration[5.1]
+class AddSuccessScriptToRepositories < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :on_success_script, :string
     add_column :builds, :promoted, :boolean

--- a/db/migrate/20121024212949_add_on_success_log_file_to_build.rb
+++ b/db/migrate/20121024212949_add_on_success_log_file_to_build.rb
@@ -1,4 +1,4 @@
-class AddOnSuccessLogFileToBuild < ActiveRecord::Migration[5.1]
+class AddOnSuccessLogFileToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :on_success_script_log_file, :string
   end

--- a/db/migrate/20121030213442_add_queue_to_repository.rb
+++ b/db/migrate/20121030213442_add_queue_to_repository.rb
@@ -1,4 +1,4 @@
-class AddQueueToRepository < ActiveRecord::Migration[5.1]
+class AddQueueToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :queue_override, :string
   end

--- a/db/migrate/20121101220831_add_timeout_to_repository.rb
+++ b/db/migrate/20121101220831_add_timeout_to_repository.rb
@@ -1,4 +1,4 @@
-class AddTimeoutToRepository < ActiveRecord::Migration[5.1]
+class AddTimeoutToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :timeout, :integer, :default => 40
   end

--- a/db/migrate/20130226232844_add_index_to_build_ref.rb
+++ b/db/migrate/20130226232844_add_index_to_build_ref.rb
@@ -1,4 +1,4 @@
-class AddIndexToBuildRef < ActiveRecord::Migration[5.1]
+class AddIndexToBuildRef < ActiveRecord::Migration[5.0]
   def change
     add_index :builds, :ref
   end

--- a/db/migrate/20130409144945_add_on_success_note_to_repositories.rb
+++ b/db/migrate/20130409144945_add_on_success_note_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddOnSuccessNoteToRepositories < ActiveRecord::Migration[5.1]
+class AddOnSuccessNoteToRepositories < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :on_success_note, :string
   end

--- a/db/migrate/20130511012855_add_deployable_map_to_build.rb
+++ b/db/migrate/20130511012855_add_deployable_map_to_build.rb
@@ -1,4 +1,4 @@
-class AddDeployableMapToBuild < ActiveRecord::Migration[5.1]
+class AddDeployableMapToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :deployable_map, :text
   end

--- a/db/migrate/20130626183046_add_maven_modules_to_build.rb
+++ b/db/migrate/20130626183046_add_maven_modules_to_build.rb
@@ -1,4 +1,4 @@
-class AddMavenModulesToBuild < ActiveRecord::Migration[5.1]
+class AddMavenModulesToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :maven_modules, :text
   end

--- a/db/migrate/20130627194433_add_index_to_build_part_paths.rb
+++ b/db/migrate/20130627194433_add_index_to_build_part_paths.rb
@@ -1,4 +1,4 @@
-class AddIndexToBuildPartPaths < ActiveRecord::Migration[5.1]
+class AddIndexToBuildPartPaths < ActiveRecord::Migration[5.0]
   def change
     add_index :build_parts, :paths, :length => {:paths => 255}
   end

--- a/db/migrate/20130709123456_add_upload_artifacts_to_build_parts.rb
+++ b/db/migrate/20130709123456_add_upload_artifacts_to_build_parts.rb
@@ -1,4 +1,4 @@
-class AddUploadArtifactsToBuildParts < ActiveRecord::Migration[5.1]
+class AddUploadArtifactsToBuildParts < ActiveRecord::Migration[5.0]
   def change
     add_column :build_parts, :upload_artifacts, :boolean
   end

--- a/db/migrate/20130822191419_add_queue_to_build_part.rb
+++ b/db/migrate/20130822191419_add_queue_to_build_part.rb
@@ -1,4 +1,4 @@
-class AddQueueToBuildPart < ActiveRecord::Migration[5.1]
+class AddQueueToBuildPart < ActiveRecord::Migration[5.0]
   def up
     add_column :build_parts, :queue, :string
 

--- a/db/migrate/20130822231850_remove_upload_artifacts_from_build_parts.rb
+++ b/db/migrate/20130822231850_remove_upload_artifacts_from_build_parts.rb
@@ -1,4 +1,4 @@
-class RemoveUploadArtifactsFromBuildParts < ActiveRecord::Migration[5.1]
+class RemoveUploadArtifactsFromBuildParts < ActiveRecord::Migration[5.0]
   def up
     remove_column :build_parts, :upload_artifacts
   end

--- a/db/migrate/20130823210844_add_retry_count_to_build_part.rb
+++ b/db/migrate/20130823210844_add_retry_count_to_build_part.rb
@@ -1,4 +1,4 @@
-class AddRetryCountToBuildPart < ActiveRecord::Migration[5.1]
+class AddRetryCountToBuildPart < ActiveRecord::Migration[5.0]
   def change
     add_column :build_parts, :retry_count, :integer, default: 0
   end

--- a/db/migrate/20130823234546_remove_queue_override_from_repositories.rb
+++ b/db/migrate/20130823234546_remove_queue_override_from_repositories.rb
@@ -1,4 +1,4 @@
-class RemoveQueueOverrideFromRepositories < ActiveRecord::Migration[5.1]
+class RemoveQueueOverrideFromRepositories < ActiveRecord::Migration[5.0]
   def up
     remove_column :repositories, :queue_override
   end

--- a/db/migrate/20130910190203_add_repository_name_as_column.rb
+++ b/db/migrate/20130910190203_add_repository_name_as_column.rb
@@ -1,4 +1,4 @@
-class AddRepositoryNameAsColumn < ActiveRecord::Migration[5.1]
+class AddRepositoryNameAsColumn < ActiveRecord::Migration[5.0]
   Rails.logger = Logger.new(STDOUT)
 
   URL_PARSERS = {

--- a/db/migrate/20131217022000_add_error_text_to_build.rb
+++ b/db/migrate/20131217022000_add_error_text_to_build.rb
@@ -1,4 +1,4 @@
-class AddErrorTextToBuild < ActiveRecord::Migration[5.1]
+class AddErrorTextToBuild < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :error_details, :text
   end

--- a/db/migrate/20140123234208_add_allows_kochiku_merges_to_repository.rb
+++ b/db/migrate/20140123234208_add_allows_kochiku_merges_to_repository.rb
@@ -1,4 +1,4 @@
-class AddAllowsKochikuMergesToRepository < ActiveRecord::Migration[5.1]
+class AddAllowsKochikuMergesToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :allows_kochiku_merges, :boolean, default: true
   end

--- a/db/migrate/20140128180258_rename_auto_merge_on_build.rb
+++ b/db/migrate/20140128180258_rename_auto_merge_on_build.rb
@@ -1,4 +1,4 @@
-class RenameAutoMergeOnBuild < ActiveRecord::Migration[5.1]
+class RenameAutoMergeOnBuild < ActiveRecord::Migration[5.0]
   def change
     rename_column :builds, :auto_merge, :merge_on_success
   end

--- a/db/migrate/20140415001051_remove_use_branches_on_green_from_repositories.rb
+++ b/db/migrate/20140415001051_remove_use_branches_on_green_from_repositories.rb
@@ -1,4 +1,4 @@
-class RemoveUseBranchesOnGreenFromRepositories < ActiveRecord::Migration[5.1]
+class RemoveUseBranchesOnGreenFromRepositories < ActiveRecord::Migration[5.0]
   def change
     remove_column :repositories, :use_branches_on_green, :boolean
   end

--- a/db/migrate/20140415011144_remove_command_flag_from_repositories.rb
+++ b/db/migrate/20140415011144_remove_command_flag_from_repositories.rb
@@ -1,4 +1,4 @@
-class RemoveCommandFlagFromRepositories < ActiveRecord::Migration[5.1]
+class RemoveCommandFlagFromRepositories < ActiveRecord::Migration[5.0]
   def change
     remove_column :repositories, :command_flag, :string
     remove_column :builds,       :target_name,  :string

--- a/db/migrate/20140506012721_unique_index_on_builds_ref.rb
+++ b/db/migrate/20140506012721_unique_index_on_builds_ref.rb
@@ -1,4 +1,4 @@
-class UniqueIndexOnBuildsRef < ActiveRecord::Migration[5.1]
+class UniqueIndexOnBuildsRef < ActiveRecord::Migration[5.0]
   def up
     remove_index :builds, column: :ref
 

--- a/db/migrate/20140507184819_add_host_and_namespace_to_repositories.rb
+++ b/db/migrate/20140507184819_add_host_and_namespace_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddHostAndNamespaceToRepositories < ActiveRecord::Migration[5.1]
+class AddHostAndNamespaceToRepositories < ActiveRecord::Migration[5.0]
   def up
     rename_column :repositories, :repository_name, :name
     change_column :repositories, :name, :string, null: false  # add not null constraint

--- a/db/migrate/20140617214701_add_success_email.rb
+++ b/db/migrate/20140617214701_add_success_email.rb
@@ -1,4 +1,4 @@
-class AddSuccessEmail < ActiveRecord::Migration[5.1]
+class AddSuccessEmail < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :build_success_email_sent, :boolean, :default => false, :null => false
     add_column :repositories, :send_build_success_email, :boolean, :default => true, :null => false

--- a/db/migrate/20140715225910_remove_notes.rb
+++ b/db/migrate/20140715225910_remove_notes.rb
@@ -1,4 +1,4 @@
-class RemoveNotes < ActiveRecord::Migration[5.1]
+class RemoveNotes < ActiveRecord::Migration[5.0]
   def change
     remove_column :repositories, :on_success_note, :string
   end

--- a/db/migrate/20141031234747_add_email_first_failure_to_repositories.rb
+++ b/db/migrate/20141031234747_add_email_first_failure_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddEmailFirstFailureToRepositories < ActiveRecord::Migration[5.1]
+class AddEmailFirstFailureToRepositories < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :email_on_first_failure, :boolean, default: false, null: false
   end

--- a/db/migrate/20150324001246_remove_on_success_script_from_repositories.rb
+++ b/db/migrate/20150324001246_remove_on_success_script_from_repositories.rb
@@ -1,4 +1,4 @@
-class RemoveOnSuccessScriptFromRepositories < ActiveRecord::Migration[5.1]
+class RemoveOnSuccessScriptFromRepositories < ActiveRecord::Migration[5.0]
   def up
     # Guard against deleting any data
     rows_with_old_data = select_value("select count(*) from repositories where on_success_script IS NOT NULL AND on_success_script != ''")

--- a/db/migrate/20150331160909_add_send_merge_successful_email.rb
+++ b/db/migrate/20150331160909_add_send_merge_successful_email.rb
@@ -1,4 +1,4 @@
-class AddSendMergeSuccessfulEmail < ActiveRecord::Migration[5.1]
+class AddSendMergeSuccessfulEmail < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :send_merge_successful_email, :boolean, default: true, null: false
   end

--- a/db/migrate/20150714234635_add_log_port_to_build_attempt.rb
+++ b/db/migrate/20150714234635_add_log_port_to_build_attempt.rb
@@ -1,4 +1,4 @@
-class AddLogPortToBuildAttempt < ActiveRecord::Migration[5.1]
+class AddLogPortToBuildAttempt < ActiveRecord::Migration[5.0]
   def change
     add_column :build_attempts, :log_streamer_port, :integer
   end

--- a/db/migrate/20150717214656_create_branches.rb
+++ b/db/migrate/20150717214656_create_branches.rb
@@ -1,4 +1,4 @@
-class CreateBranches < ActiveRecord::Migration[5.1]
+class CreateBranches < ActiveRecord::Migration[5.0]
   def change
     create_table :branches do |t|
       t.references :repository, null: false

--- a/db/migrate/20150717220149_assign_builds_to_branches.rb
+++ b/db/migrate/20150717220149_assign_builds_to_branches.rb
@@ -1,6 +1,6 @@
 # In this migration intentionally go out of our way to not use the Project
 # model so that it can be removed from the codebase.
-class AssignBuildsToBranches < ActiveRecord::Migration[5.1]
+class AssignBuildsToBranches < ActiveRecord::Migration[5.0]
   def up
     # Be mindful of build.branch versus build#branch_id
     # `build.branch` is a reference to the name of the branch as a string

--- a/db/migrate/20150717231250_remove_branch_string_from_builds.rb
+++ b/db/migrate/20150717231250_remove_branch_string_from_builds.rb
@@ -1,4 +1,4 @@
-class RemoveBranchStringFromBuilds < ActiveRecord::Migration[5.1]
+class RemoveBranchStringFromBuilds < ActiveRecord::Migration[5.0]
   def change
     # The previous migration (AssignBuildsToBranches) mapped branch_id on
     # builds to the newly introduced Branch records. With that complete it is

--- a/db/migrate/20150719130110_index_repositories_namespace_and_name.rb
+++ b/db/migrate/20150719130110_index_repositories_namespace_and_name.rb
@@ -1,4 +1,4 @@
-class IndexRepositoriesNamespaceAndName < ActiveRecord::Migration[5.1]
+class IndexRepositoriesNamespaceAndName < ActiveRecord::Migration[5.0]
   def change
     add_index :repositories, [:namespace, :name], unique: true
   end

--- a/db/migrate/20151111080255_remove_repo_cache_dir_from_repositories.rb
+++ b/db/migrate/20151111080255_remove_repo_cache_dir_from_repositories.rb
@@ -1,4 +1,4 @@
-class RemoveRepoCacheDirFromRepositories < ActiveRecord::Migration[5.1]
+class RemoveRepoCacheDirFromRepositories < ActiveRecord::Migration[5.0]
   def change
     remove_column :repositories, :repo_cache_dir, :string
   end

--- a/db/migrate/20151114185514_fix_convergence_index.rb
+++ b/db/migrate/20151114185514_fix_convergence_index.rb
@@ -1,6 +1,6 @@
 # In order for the index on convergence col to be useful it needs to be
 # namespaced by repository_id
-class FixConvergenceIndex < ActiveRecord::Migration[5.1]
+class FixConvergenceIndex < ActiveRecord::Migration[5.0]
   def change
     # Add the new index first to avoid killing performance
     add_index :branches, [:repository_id, :convergence]

--- a/db/migrate/20160408214135_index_created_at_on_build_attempts.rb
+++ b/db/migrate/20160408214135_index_created_at_on_build_attempts.rb
@@ -1,4 +1,4 @@
-class IndexCreatedAtOnBuildAttempts < ActiveRecord::Migration[5.1]
+class IndexCreatedAtOnBuildAttempts < ActiveRecord::Migration[5.0]
   def change
     add_index :build_attempts, :created_at
   end

--- a/db/migrate/20170804214538_add_enabled_bool_to_repositories.rb
+++ b/db/migrate/20170804214538_add_enabled_bool_to_repositories.rb
@@ -1,4 +1,4 @@
-class AddEnabledBoolToRepositories < ActiveRecord::Migration[5.1]
+class AddEnabledBoolToRepositories < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :enabled, :boolean, default: true, null: false
   end

--- a/db/migrate/20180208202524_add_test_command_to_builds.rb
+++ b/db/migrate/20180208202524_add_test_command_to_builds.rb
@@ -1,4 +1,4 @@
-class AddTestCommandToBuilds < ActiveRecord::Migration[5.1]
+class AddTestCommandToBuilds < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :test_command, :string
   end

--- a/db/migrate/20180220185338_add_assume_lost_after_to_repository.rb
+++ b/db/migrate/20180220185338_add_assume_lost_after_to_repository.rb
@@ -1,4 +1,4 @@
-class AddAssumeLostAfterToRepository < ActiveRecord::Migration[5.1]
+class AddAssumeLostAfterToRepository < ActiveRecord::Migration[5.0]
   def change
     add_column :repositories, :assume_lost_after, :integer
   end

--- a/db/migrate/20180227222254_add_initiated_by_to_builds.rb
+++ b/db/migrate/20180227222254_add_initiated_by_to_builds.rb
@@ -1,4 +1,4 @@
-class AddInitiatedByToBuilds < ActiveRecord::Migration[5.1]
+class AddInitiatedByToBuilds < ActiveRecord::Migration[5.0]
   def change
     add_column :builds, :initiated_by, :string
   end

--- a/db/migrate/20180301221320_add_instance_type_to_build_attempts.rb
+++ b/db/migrate/20180301221320_add_instance_type_to_build_attempts.rb
@@ -1,4 +1,4 @@
-class AddInstanceTypeToBuildAttempts < ActiveRecord::Migration[5.1]
+class AddInstanceTypeToBuildAttempts < ActiveRecord::Migration[5.0]
   def change
     add_column :build_attempts, :instance_type, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,8 +12,8 @@
 
 ActiveRecord::Schema.define(version: 20180301221320) do
 
-  create_table "branches", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.bigint "repository_id", null: false
+  create_table "branches", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer "repository_id", null: false
     t.string "name", null: false
     t.boolean "convergence", default: false, null: false
     t.datetime "created_at", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["repository_id"], name: "index_branches_on_repository_id"
   end
 
-  create_table "build_artifacts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "build_artifacts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "build_attempt_id"
     t.string "log_file"
     t.datetime "created_at", null: false
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["build_attempt_id"], name: "index_build_artifacts_on_build_attempt_id"
   end
 
-  create_table "build_attempts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "build_attempts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "build_part_id"
     t.datetime "started_at"
     t.datetime "finished_at"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["created_at"], name: "index_build_attempts_on_created_at"
   end
 
-  create_table "build_parts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "build_parts", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer "build_id"
     t.string "kind"
     t.text "paths"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["paths"], name: "index_build_parts_on_paths", length: { paths: 255 }
   end
 
-  create_table "builds", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "builds", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "ref", limit: 40, null: false
     t.string "state"
     t.datetime "created_at", null: false
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.string "on_success_script_log_file"
     t.text "error_details"
     t.boolean "build_success_email_sent", default: false, null: false
-    t.bigint "branch_id"
+    t.integer "branch_id"
     t.string "test_command"
     t.string "initiated_by"
     t.index ["branch_id"], name: "index_builds_on_branch_id"
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["ref", "project_id"], name: "index_builds_on_ref_and_project_id", unique: true
   end
 
-  create_table "projects", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "projects", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
     t.string "branch"
     t.datetime "created_at", null: false
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 20180301221320) do
     t.index ["repository_id"], name: "index_projects_on_repository_id"
   end
 
-  create_table "repositories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "repositories", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "url"
     t.string "test_command"
     t.datetime "created_at", null: false


### PR DESCRIPTION
Rails 5.1 changes the default types for primary keys to bigint.