### PR TITLE
PollRepositoriesJob does not need to check every convergence branch

### DIFF
--- a/app/jobs/poll_repositories_job.rb
+++ b/app/jobs/poll_repositories_job.rb
@@ -1,11 +1,11 @@
 class PollRepositoriesJob
   def self.perform
-    Branch.joins(:repository)
-          .where(convergence: true, 'repositories.enabled': true)
-          .includes(:repository)
-          .find_each(batch_size: 20) do |branch|
+    Repository.where(enabled: true).find_each(batch_size: 10) do |repo|
+      branch = repo.convergence_branches.first || repo.branches.where(name: 'master').first
 
-      repo = branch.repository
+      if branch.nil?
+        Rails.logger.warn("[PollRepositoriesJob] Could not find a branch to check for repo #{repo.name_with_namespace}")
+      end
 
       begin
         head = repo.sha_for_branch(branch.name)


### PR DESCRIPTION
Instead of checking every convergence branch for a repository, only check the first one. Check 'master' branch is no convergence branches are specified.

The previous implementation would inadvertently disable the repository if one of the convergence branches was deleted. That could still happen but at least with this implementation it will be less likely because it is only looking at the first convergence branch.