### PR TITLE
Round robin files that do not appear in the time manifest

### DIFF
--- a/lib/partitioner/default.rb
+++ b/lib/partitioner/default.rb
@@ -101,8 +101,6 @@ module Partitioner
       file_to_times_hash.slice!(*all_files)
       min_test_time = file_to_times_hash.values.flatten.min || 1
       setup_time = min_test_time / 2
-      # Any new tests get added in here.
-      all_files.each  { |file| file_to_times_hash[file] ||= [min_test_time] }
 
       files_by_worker = []
       runtimes_by_worker = []
@@ -118,6 +116,11 @@ module Partitioner
           runtimes_by_worker[fastest_worker_index] += file_runtime - setup_time
         end
       end
+
+      # Add any missing files
+      missing_files = all_files - file_to_times_hash.keys
+      files_by_worker = files_by_worker.zip(missing_files.in_groups(workers)).map(&:flatten).map(&:compact)
+
       files_by_worker
     end
 

--- a/spec/lib/partitioner/shared_default_behavior.rb
+++ b/spec/lib/partitioner/shared_default_behavior.rb
@@ -276,9 +276,9 @@ RSpec.shared_examples "Partitioner::Default behavior" do |partitioner_class|
 
             it 'should greedily partition files in the time_manifest, and round robin the remaining files' do
               partitions = subject
-              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['c.spec'] }))
-              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['d.spec', 'e.spec'] }))
-              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['b.spec', 'a.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['c.spec', 'e.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['d.spec', 'a.spec'] }))
+              expect(partitions).to include(a_hash_including({ 'type' => 'rspec', 'files' => ['b.spec'] }))
               expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['i.feature'] }))
               expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['h.feature'] }))
               expect(partitions).to include(a_hash_including({ 'type' => 'cuke', 'files' => ['g.feature', 'f.feature']}))


### PR DESCRIPTION
Assuming new files will be fast means they are more likely to be grouped together, which means adding a couple of slow files can drastically slow down one worker. Since we don't know if they will be fast or not we should spread them out as much as possible.