### PR TITLE
Make build attempts easier to debug

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -595,6 +595,9 @@ table
     white-space: normal
     line-height: 1.6
 
+  tr:target td
+    background-color: #ffc
+
 /* Search by build revision
 .select_commit
   margin-bottom: 20px

--- a/app/controllers/build_attempts_controller.rb
+++ b/app/controllers/build_attempts_controller.rb
@@ -37,15 +37,16 @@ class BuildAttemptsController < ApplicationController
     end
   end
 
-  # Redirects to the show page for the build_attempt's build_part. Added as a
-  # shortcut method to use when the IDs of the relation chain is not handy.
-  def build_part
+  # Redirects to the build_part page since we don't have a page for a single build attempt.
+  # Added as a shortcut method to use when the IDs of the relation chain is not handy.
+  def show
     @build_attempt = BuildAttempt.find(params[:id])
 
-    redirect_to repository_build_part_path(
+    redirect_to repository_build_part_url(
       @build_attempt.build_part.build_instance.repository,
       @build_attempt.build_part.build_instance,
-      @build_attempt.build_part)
+      @build_attempt.build_part,
+      anchor: helpers.dom_id(@build_attempt))
   end
 
   def stream_logs

--- a/app/views/build_parts/_build_attempts.html.haml
+++ b/app/views/build_parts/_build_attempts.html.haml
@@ -1,5 +1,5 @@
-%tr{:"data-id" => index + 1}
-  %td.right= index + 1
+%tr{id: dom_id(attempt), :"data-id" => index + 1}
+  %td.right= link_to(index + 1, attempt)
   %td
     %span.attempt-status{:class => attempt.state}= attempt.state.to_s.capitalize
   %td.rank= build_attempts_rank[attempt.id.to_s]

--- a/app/views/dashboards/build_history_by_worker.html.haml
+++ b/app/views/dashboards/build_history_by_worker.html.haml
@@ -28,5 +28,5 @@
           %td.right= worker_name
           %td
             - build_attempts.each do |build_attempt|
-              = link_to build_part_redirect_path(build_attempt) do
+              = link_to build_attempt do
                 %span.attempt-status{:class => build_attempt.state}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,8 @@ Kochiku::Application.routes.draw do
   match '/build_attempts/:build_attempt_id/build_artifacts' => "build_artifacts#create", :via => :post
   match '/build_attempts/:id/start' => "build_attempts#start", :via => :post
   match '/build_attempts/:id/finish' => "build_attempts#finish", :via => :post, :as => :finish_build_attempt
-  match '/build_attempts/:id/build_part' => "build_attempts#build_part", :via => :get, :as => :build_part_redirect
+  # left here for backward compatibility in case if anyone uses it. /build_attempts/:id should be used instead.
+  match '/build_attempts/:id/build_part' => "build_attempts#show", :via => :get, :as => :build_part_redirect
   match '/build_attempts/:id/stream_logs' => "build_attempts#stream_logs", :via => :get, :as => :stream_logs
   match '/build_attempts/:id/stream_logs_chunk' => "build_attempts#stream_logs_chunk", :via => :get, :as => :stream_logs_chunk
   match '/pull-request-builder' => "pull_requests#build", :via => :post, :as => :pull_request_build
@@ -40,6 +41,7 @@ Kochiku::Application.routes.draw do
 
   resources :build_artifacts, :only => [:show]
   resources :builds, only: [:create]
+  resources :build_attempts, only: [:show]
 
   scope path: "*repository_path", as: 'repository', constraints: { repository_path: /[^\/]+\/[^\/]+/ }, format: false do
     get 'edit', to: 'repositories#edit'


### PR DESCRIPTION
I have 2 problems debugging build attempts:

1. When I have a build attempt ID from a worker and try to find it in UI I always type `/build_attempts/:id` first and they realize that I need to type `/build_attempts/:id/build_part` instead. This change adds `/build_attempts/:id` endpoint but keeps old one for backward compatibility.

2. When I’m on a build part page and see some build attempts failed or errored I have no way to get their IDs for debugging purposes. This change adds a link to a build attempt position that can be shared or used to extract ID from it.

<img width="1191" alt="screen shot 2018-05-29 at 12 40 41 pm" src="https://user-images.githubusercontent.com/805/40681637-8b65dbd4-633e-11e8-964e-8c5c5372f124.png">