### PR TITLE
Add aws url to log file json

### DIFF
--- a/app/models/build_artifact.rb
+++ b/app/models/build_artifact.rb
@@ -13,7 +13,7 @@ class BuildArtifact < ActiveRecord::Base
     super(except: "log_file").tap do |hash|
       log_file = {
         "url" => Rails.application.routes.url_helpers.build_artifact_path(self),
-        "aws_url" => self.log_file.url
+        "aws_url" => self.log_file.url,
         "name" => self.log_file.path
       }
       hash["build_artifact"]["log_file"] = log_file

--- a/app/models/build_artifact.rb
+++ b/app/models/build_artifact.rb
@@ -11,7 +11,11 @@ class BuildArtifact < ActiveRecord::Base
 
   def as_json
     super(except: "log_file").tap do |hash|
-      log_file = {"url" => Rails.application.routes.url_helpers.build_artifact_path(self), "name" => self.log_file.path}
+      log_file = {
+        "url" => Rails.application.routes.url_helpers.build_artifact_path(self),
+        "aws_url" => self.log_file.url
+        "name" => self.log_file.path
+      }
       hash["build_artifact"]["log_file"] = log_file
     end
   end


### PR DESCRIPTION
I want to be able to easily get to the log files programmatically without having to go through an authenticated redirect. 

I have a work around if we don't want to share the aws urls at all, but this just makes a script that downloads all pngs from a build part slightly faster. 