### PR TITLE
Hacky fix to hide overflow on firefox

### DIFF
--- a/app/assets/stylesheets/screen.sass
+++ b/app/assets/stylesheets/screen.sass
@@ -546,9 +546,9 @@ table
 
   td
     padding: 5px
-    overflow-x: scroll
     white-space: nowrap
-    /* Fix chrome 67 formating issue
+    overflow-x: scroll
+    /* Fix chrome 67 formating issue */
     position: relative
 
     &::-webkit-scrollbar
@@ -766,3 +766,12 @@ p
 
 .worker-health
   table-layout: auto
+
+// Firefox doesn't support a fixed table with
+// a scroll overflow, so just hide the overflow on Firefox.
+// It also doesn't react to just overflow-x, we need to hide
+// overflow in both axes
+@-moz-document url-prefix()
+  table
+    td
+      overflow: hidden


### PR DESCRIPTION
this probably isn't the best way to do this, but I couldn't get the exiting fixed table layout + overflow scroll working in firefox. 

before: 
<img width="751" alt="screen shot 2018-06-11 at 10 35 53 pm" src="https://user-images.githubusercontent.com/39384186/41271908-d78d0648-6dc7-11e8-9e82-54e0f6d5e427.png">

after 
<img width="751" alt="screen shot 2018-06-11 at 10 35 48 pm" src="https://user-images.githubusercontent.com/39384186/41271910-db1d3242-6dc7-11e8-8904-90632717b883.png">


fine with just always hiding overflow scroll but that seems like a loss. fwiw, cmd+f for firefox doesn't seem to find things that aren't visible on the page. 

another alternative is to just always show all of the tests: e.g. 
<img width="748" alt="screen shot 2018-06-11 at 10 34 49 pm" src="https://user-images.githubusercontent.com/39384186/41271875-b0d90fe2-6dc7-11e8-9a72-ff064d059824.png">
